### PR TITLE
remove treebeard API key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,6 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: treebeardtech/treebeard@master
         with:
-          api-key: ${{ secrets.TREEBEARD_API_KEY }}
           docker-username: "jaimergp"
           docker-password: "${{ secrets.DOCKERHUB_PASSWORD }}"
           docker-image-name: "volkamerlab/teachopencadd"


### PR DESCRIPTION
hey folks -- sorry to say, due to my google cloud credits running out and a misunderstanding, my GCP account has just been nuked and uploads are out of action.

I should be able to retrieve any stored data if you need but this is likely a permanent change as I was planning on deprecating the backend.

Again, sorry for the lack of warning. Fortunately I have a more open replacement to this capability coming very soon.