### PR TITLE
Fix unwanted scrollbars in Edge Legacy

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -471,3 +471,10 @@ a.sphx-glr-backref-instance {
 .cc-floating.cc-type-info.cc-theme-classic .cc-btn {
   display: inline-block;
 }
+
+/* Fix unwanted scrollbars in Edge Legacy */
+div.nbinput.container div.input_area > div[class^="highlight"],
+div.nboutput.container div.output_area > div[class^="highlight"] {
+  overflow-y: hidden;
+  overflow-x: hidden;
+}


### PR DESCRIPTION
Before fix:

![image](https://user-images.githubusercontent.com/2559438/102711936-991d0480-42bd-11eb-9fbf-1614d248c2c5.png)

After fix (`molecules` is no longer covered by the unwanted scrollbar):

![image](https://user-images.githubusercontent.com/2559438/102711921-80145380-42bd-11eb-924e-107a35c0d37e.png)


---

Thanks @bra1n for the fix!