### PR TITLE
adds visual inspection to docking theory

### DIFF
--- a/teachopencadd/talktorials/T015_protein_ligand_docking/README.md
+++ b/teachopencadd/talktorials/T015_protein_ligand_docking/README.md
@@ -17,14 +17,15 @@ In this talktorial, we will use molecular docking to predict the binding mode of
 - Molecular docking
 - Sampling algorithms
 - Scoring functions
-- Known limitations
-- Docking softwares
+- Limitations
+- Visual inspection
+- Docking software
   - Commercial
   - Free (for academics)
 
 ### Contents in *Practical*
 
-- Protein and ligand preparation
+- Preparation of protein and ligand
 - Binding site definition
 - Docking calculation
 - Docking results visualization
@@ -36,6 +37,7 @@ In this talktorial, we will use molecular docking to predict the binding mode of
 - Warren et al. 2006 _A critical assessment of docking programs and scoring functions_ ([_J Med Chem_ (2006), __49__, 20, 5912-31](https://doi.org/10.1021/jm050362n))
 - Wang et al. 2016 _Comprehensive evaluation of ten docking programs on a diverse set of protein-ligand complexes: the prediction accuracy of sampling power and scoring power_ ([_Phys Chem Chem Phys_ (2016), __18__, 18, 12964-75](https://doi.org/10.1039/c6cp01555g))
 - Koes et al. 2013 _Lessons Learned in Empirical Scoring with smina from the CSAR 2011 Benchmarking Exercise_ ([_J Chem Inf Model_ (2013), __53__, 8, 1893-1904](https://doi.org/10.1021/ci300604z))
+- Fischer et al. 2021 _Decision Making in Structure-Based Drug Discovery: Visual Inspection of Docking Results_ ([_J Med Chem_ (2021)](https://doi.org/10.1021/acs.jmedchem.0c02227))
 - [OpenBabel](http://openbabel.org/wiki/Main_Page)
 - [Smina](https://sourceforge.net/projects/smina/)
 - [NGLView](http://nglviewer.org/nglview/latest/)

--- a/teachopencadd/talktorials/T015_protein_ligand_docking/talktorial.ipynb
+++ b/teachopencadd/talktorials/T015_protein_ligand_docking/talktorial.ipynb
@@ -34,6 +34,7 @@
     "- Sampling algorithms\n",
     "- Scoring functions\n",
     "- Limitations\n",
+    "- Visual inspection\n",
     "- Docking software\n",
     "  - Commercial\n",
     "  - Free (for academics)"
@@ -62,6 +63,7 @@
     "- Warren et al. 2006 _A critical assessment of docking programs and scoring functions_ ([_J Med Chem_ (2006), __49__, 20, 5912-31](https://doi.org/10.1021/jm050362n))\n",
     "- Wang et al. 2016 _Comprehensive evaluation of ten docking programs on a diverse set of protein-ligand complexes: the prediction accuracy of sampling power and scoring power_ ([_Phys Chem Chem Phys_ (2016), __18__, 18, 12964-75](https://doi.org/10.1039/c6cp01555g))\n",
     "- Koes et al. 2013 _Lessons Learned in Empirical Scoring with smina from the CSAR 2011 Benchmarking Exercise_ ([_J Chem Inf Model_ (2013), __53__, 8, 1893-1904](https://doi.org/10.1021/ci300604z))\n",
+    "- Fischer et al. 2021 _Decision Making in Structure-Based Drug Discovery: Visual Inspection of Docking Results_ ([_J Med Chem_ (2021)](https://doi.org/10.1021/acs.jmedchem.0c02227))\n",
     "- [OpenBabel](http://openbabel.org/wiki/Main_Page)\n",
     "- [Smina](https://sourceforge.net/projects/smina/)\n",
     "- [NGLView](http://nglviewer.org/nglview/latest/)"
@@ -182,6 +184,27 @@
     "Scoring functions used by docking programs must be cheap to compute. While the accuracy is good enough to distinguish good poses from bad poses, it can have problems sorting the best poses. For example, while most popular docking programs are able to find the experimental pose in their calculations, this pose is rarely the best one of the proposed set. Furthermore, several retrospective studies have shown that docking scores often poorly correlate with binding affinity ([_J Med Chem_ (2006), __49__, 20, 5912-31](https://doi.org/10.1021/jm050362n), [_Phys Chem Chem Phys_ (2016), __18__, 18, 12964-75](https://doi.org/10.1039/c6cp01555g)).  \n",
     "To reduce the computational cost, docking procedures are only performed in a subset of the protein (normally around a known binding pocket). Choosing the correct binding site can become another challenge, if the binding pocket is not known a priori.  \n",
     "To maximize the accuracy of the calculation, the ligand and protein structures must be prepared appropriately. Protonation states of amino acids and the ligands can be tricky to get right, especially in the case of (potential) tautomers. This introduces yet another cause to obtain wrong results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visual inspection\n",
+    "\n",
+    "Due to the afore mentioned limitations of sampling algorithms and docking scoring functions a visual inspection is commonly performed in most docking scenarios. Interestingly, a survey revealed that molecular modeling experts find docking scores to be the least important criterion for selecting docking poses ([_J Med Chem_ (2021)](https://doi.org/10.1021/acs.jmedchem.0c02227)). Instead, the following criteria are used when selecting docking poses:  \n",
+    "- similarity to binding modes observed in available crystal structures of the protein of interest  \n",
+    "- steric as well as electrostatic and hydrophobic complementary of ligand and protein  \n",
+    "  - unsatisfied hydrogen bond donor and acceptor groups in ligand and protein  \n",
+    "  - solvent exposed hydrophobic ligand moieties  \n",
+    "- interactions with side chains or metal ions critical for protein function, e.g. enzymatic activity\n",
+    "- interaction partners and localization of hydrogen bonds\n",
+    "  - hydrogen bonds formed with the protein backbone in an enclosed hydrophobic protein environment are considered more favorable  \n",
+    "  - hydrogen bonds with charged and solvent exposed protein side chains are considered less favorable  \n",
+    "- displacement of or interactions with water molecules in the binding pocket  \n",
+    "- protein and ligand strain induced by ligand binding  \n",
+    "\n",
+    "However, also the visual inspection of docking poses has considerable limitations. Of course the success of visual inspection strongly depends on the experience and intuition of the participating scientists. Also, visual inspection can only be performed for a rather small number of molecules considering the available chemical space in virtual screening. Hence, visual inspection is often restricted to the highest scoring molecules of a virtual screening pipeline or only performed for a smaller set of ligands, in which scientists are particularly interested. Finally, also the best expert cannot pick the correct binding pose if it was not sampled by the docking program."
    ]
   },
   {


### PR DESCRIPTION
This PR adds a visual inspection section to the Theory of the docking talktorial. The section is based on the newly published paper in [J Med Chem](https://pubs.acs.org/doi/10.1021/acs.jmedchem.0c02227).