### PR TITLE
Enable CI on windows for T019

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,7 @@ jobs:
         shell: bash -l {0}
         run: |
           PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
-          if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
-          else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ --ignore-glob=teachopencadd/talktorials/T019*
-          fi
+          pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
 
   format:
     name: Black

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         cfg:
           - os: ubuntu-latest
-            python-version: "3.6"
+            python-version: "3.7"
           - os: ubuntu-latest
             python-version: "3.9"
           - os: macos-latest
-            python-version: "3.6"
+            python-version: "3.7"
           - os: windows-latest
-            python-version: "3.6"
+            python-version: "3.7"
 
     env:
       PYVER: ${{ matrix.cfg.python-version }}
@@ -66,7 +66,8 @@ jobs:
       - name: Test CLI
         shell: bash -l {0}
         run: |
-          teachopencadd
+          teachopencadd -h
+          pytest -v --cov=${PACKAGE} --cov-report=xml --color=yes ${PACKAGE}/tests/
 
       - name: Run tests
         shell: bash -l {0}
@@ -117,7 +118,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
           channel-priority: true
           auto-activate-base: true
           channels: conda-forge,defaults


### PR DESCRIPTION
The issue behind the failing CI on Windows for T019 appears to be fixed ([#2409](https://github.com/openbabel/openbabel/issues/2409)).

## ToDos

- [x] enable CI on Windows for T019
- [ ] tests pass

## Status
- [ ] Ready to go