### PR TITLE
Add `numpy`+`jsonschema` to env + drop Python 3.6 in CI (use 3.7 instead)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,11 @@ jobs:
         shell: bash -l {0}
         run: |
           PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
-          pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
+          if [ "$RUNNER_OS" != "Windows" ]; then
+            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
+          else
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ --ignore-glob=teachopencadd/talktorials/T019*
+          fi
 
   format:
     name: Black

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         cfg:
           - os: ubuntu-latest
-            python-version: "3.6"
+            python-version: "3.7"
           - os: ubuntu-latest
             python-version: "3.9"
           - os: macos-latest
-            python-version: "3.6"
+            python-version: "3.7"
           - os: windows-latest
-            python-version: "3.6"
+            python-version: "3.7"
 
     env:
       PYVER: ${{ matrix.cfg.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,7 @@ jobs:
         shell: bash -l {0}
         run: |
           PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
-          if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
-          else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ --ignore-glob=teachopencadd/talktorials/T019*
-          fi
+          pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
 
   format:
     name: Black

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
           channel-priority: true
           auto-activate-base: true
           channels: conda-forge,defaults

--- a/devtools/other-conda-envs/users_env.yml
+++ b/devtools/other-conda-envs/users_env.yml
@@ -2,10 +2,12 @@ name: teachopencadd
 channels:
   - conda-forge
 dependencies:
-  - python>=3.6
+  - python>=3.7
   - pip
   - jupyter
   - jupyterlab>=3
+  # Explicitly add numpy because of https://github.com/volkamerlab/teachopencadd/issues/150
+  - numpy
   - rdkit>=2021.03
   - scikit-learn
   - biopandas

--- a/devtools/other-conda-envs/users_env.yml
+++ b/devtools/other-conda-envs/users_env.yml
@@ -20,6 +20,8 @@ dependencies:
   - openbabel
   - tqdm
   - lxml
+  # Remove jsonschema once this issue is fixed: https://github.com/Yelp/bravado/issues/478
+  - jsonschema<4.0.0
   - bravado
   - beautifulsoup4
   - ipywidgets>=7.5

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - jupyter
   - jupyterlab>=3
+  - numpy
   - rdkit>=2021.03
   - scikit-learn
   - biopandas

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -2,7 +2,7 @@
 channels:
   - conda-forge
 dependencies:
-  - python>=3.6
+  - python>=3.7
   - pip
   - jupyter
   - jupyterlab>=3

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - jupyter
   - jupyterlab>=3
+  # Explicitly add numpy because of https://github.com/volkamerlab/teachopencadd/issues/150
   - numpy
   - rdkit>=2021.03
   - scikit-learn

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -20,6 +20,8 @@ dependencies:
   - openbabel
   - tqdm
   - lxml
+  # Remove jsonschema once this issue is fixed: https://github.com/Yelp/bravado/issues/478
+  - jsonschema<4.0.0
   - bravado
   - beautifulsoup4
   - ipywidgets>=7.5


### PR DESCRIPTION
## Description
See issue: https://github.com/volkamerlab/teachopencadd/issues/150

## Todos
- [x] Fix env (workaround): `numpy` version conflicts with `mdanalysis`: Add `numpy` to `test_env.yml`
- [x] Fix env (workaround): `jsonschema` version shipped with `bravado` (<4.0.0) comes without a necessary module, thus manually install `jsonschema` <4.0.0 here *until this is fixed in bravado/swagger_spec_validator or else - REVISIT THIS* Opened issue as a reminder: https://github.com/volkamerlab/teachopencadd/issues/152
- [x] Config CI for Python 3.7 instead of 3.6
  - Python 3.6 support may become more and more complicated with that many packages we are using
  - Examples
    - https://github.com/volkamerlab/teachopencadd/pull/146
    - https://deeptalk.lambdalabs.com/t/cant-build-keras-model-after-tensorflow-update-from-2-2-to-2-3/1799
    - https://bugs.gentoo.org/806541 
- [x] Add comment  to envs "Explicitly add numpy because: https://github.com/volkamerlab/teachopencadd/issues/150"
- [x] Streamline all envs: test and users envs
- [x] Check if CI passes

## Questions
None

## Status
- [x] Ready to go