### PR TITLE
Add `teachopencadd start workspace` CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         shell: bash -l {0}
         run: |
           teachopencadd
+          pytest -v --cov=${PACKAGE} --cov-report=xml --color=yes ${PACKAGE}/tests/
 
       - name: Run tests
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Test CLI
         shell: bash -l {0}
         run: |
-          teachopencadd
+          teachopencadd -h
           pytest -v --cov=${PACKAGE} --cov-report=xml --color=yes ${PACKAGE}/tests/
 
       - name: Run tests

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -46,6 +46,7 @@ dependencies:
   # Workaround for https://github.com/computationalmodelling/nbval/issues/153
   - pytest 5.*
   - pytest-xdist
+  - pytest-cov
   - nbval
   - shyaml
   ## Docs

--- a/teachopencadd/cli.py
+++ b/teachopencadd/cli.py
@@ -3,16 +3,82 @@ Command Line Interface for the project.
 """
 
 from pathlib import Path
+import argparse
+import subprocess
+import shutil
+
+from teachopencadd.utils import _greeting_string, _run_jlab_string, _talktorial_list_string
 from . import _version
+
+TALKTORIAL_FOLDER_NAME = "teachopencadd-talktorials"
 
 
 def main():
-    print(f"TeachOpenCADD CLI {_version.get_versions()['version']}")
-    talktorials_dir = Path(_version.__file__).parent / "talktorials"
-    if talktorials_dir.is_dir():
-        print("Available talktorials:")
-        for d in sorted(talktorials_dir.glob("*/")):
-            if (d / "talktorial.ipynb").exists():
-                print("  -", d.name)
-    else:
-        raise RuntimeError(f"Could not find talktorials at expected location `{talktorials_dir}`")
+    """
+    Main CLI function enabling the following signatures:
+    - teachopencadd start path/to/workspace
+    """
+
+    print(_greeting_string())
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    # Subcommand `start`
+    subparser_start = subparsers.add_parser("start")
+    subparser_start.add_argument(
+        "workspace", type=str, help="Path to directory for user workspace"
+    )
+    subparser_start.set_defaults(func=_start)
+
+    # For future additional subcommands (e.g. `teachopencadd test`),
+    # - copy the `subparser_start` code block above,
+    # - replace `start` with `test`, and
+    # - add a function called `test` that implements the behavior you want.
+
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except AttributeError:
+        # Run help if no arguments were given
+        subprocess.run(["teachopencadd", "-h"])
+
+
+def _start(args):
+    """
+    Starts a new TeachOpenCADD workspace.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Arguments for start subcommand.
+
+    Notes
+    -----
+    Procedure:
+    - copy all talktorial folders to a folder called `TALKTORIAL_FOLDER_NAME` in a user-defined
+      directory
+    - if such a folder already exists, do nothing but print message
+    - print list of talktorials in workspace
+    - print instructions on how to fire up the talktorials in JupyterLab
+    """
+
+    # Source and destination directories for talktorials
+    talktorials_src_dir = Path(_version.__file__).parent / "talktorials"
+    talktorials_dst_dir = Path(args.workspace) / TALKTORIAL_FOLDER_NAME
+
+    if not Path(args.workspace).is_dir():
+        raise RuntimeError(f"Could not find user-defined location `{args.workspace}`")
+
+    if not talktorials_src_dir.is_dir():
+        raise RuntimeError(
+            f"Could not find talktorials at expected location `{talktorials_src_dir}`"
+        )
+
+    try:
+        shutil.copytree(talktorials_src_dir, talktorials_dst_dir)
+    except FileExistsError:
+        print(f"Workspace exists already at location {talktorials_dst_dir}.")
+
+    print(_talktorial_list_string(talktorials_dst_dir))
+    print(_run_jlab_string(talktorials_dst_dir))

--- a/teachopencadd/cli.py
+++ b/teachopencadd/cli.py
@@ -68,11 +68,11 @@ def _start(args):
     talktorials_dst_dir = Path(args.workspace) / TALKTORIAL_FOLDER_NAME
 
     if not Path(args.workspace).is_dir():
-        raise RuntimeError(f"Could not find user-defined location `{args.workspace}`")
+        raise RuntimeError(f"Could not find user-defined location `{args.workspace}`.")
 
     if not talktorials_src_dir.is_dir():
         raise RuntimeError(
-            f"Could not find talktorials at expected location `{talktorials_src_dir}`"
+            f"Could not find talktorials at expected location `{talktorials_src_dir}`."
         )
 
     try:

--- a/teachopencadd/cli.py
+++ b/teachopencadd/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import argparse
 import subprocess
 import shutil
+import sys
 
 from teachopencadd.utils import _greeting_string, _run_jlab_string, _talktorial_list_string
 from . import _version
@@ -68,17 +69,17 @@ def _start(args):
     talktorials_dst_dir = Path(args.workspace) / TALKTORIAL_FOLDER_NAME
 
     if not Path(args.workspace).is_dir():
-        raise RuntimeError(f"Could not find user-defined location `{args.workspace}`.")
+        print(f"Could not find user-defined location `{args.workspace}`.")
+        sys.exit()
 
     if not talktorials_src_dir.is_dir():
-        raise RuntimeError(
-            f"Could not find talktorials at expected location `{talktorials_src_dir}`."
-        )
+        print(f"Could not find talktorials at expected location `{talktorials_src_dir}`.")
+        sys.exit()
 
     try:
         shutil.copytree(talktorials_src_dir, talktorials_dst_dir)
     except FileExistsError:
-        print(f"Workspace exists already at location {talktorials_dst_dir}.")
+        print(f"Workspace exists already at location `{talktorials_dst_dir}`.")
 
     print(_talktorial_list_string(talktorials_dst_dir))
     print(_run_jlab_string(talktorials_dst_dir))

--- a/teachopencadd/tests/test_cli.py
+++ b/teachopencadd/tests/test_cli.py
@@ -5,6 +5,7 @@ Unit tests for Command Line Interface.
 from pathlib import Path
 import shutil
 import subprocess
+import warnings
 
 from teachopencadd.utils import (
     _greeting_string,
@@ -107,3 +108,17 @@ def test_start_incorrect_workspace():
     assert exitcode == 0
     assert out == _greeting_string() + "\n" + "Could not find user-defined location `xxx`.\n"
     assert not err
+
+
+def test_jlab_import():
+    """
+    Add warning if JupyterLab cannot be imported.
+    """
+
+    try:
+        import jupyterlab
+    except ImportError:
+        warnings.warn(
+            "JupyterLab cannot be imported; install with `mamba install jupyterlab`.",
+            ImportWarning,
+        )

--- a/teachopencadd/tests/test_cli.py
+++ b/teachopencadd/tests/test_cli.py
@@ -14,6 +14,24 @@ from teachopencadd.cli import TALKTORIAL_FOLDER_NAME
 
 
 def capture(command):
+    """
+    Run input command as subprocess and caputure the subprocess' exit code, stdout and stderr.
+
+    Parameters
+    ----------
+    command : list of str
+        Command to be run as subprocess.
+
+    Returns
+    -------
+    out : bytes
+        Standard output message.
+    err : bytes
+        Standard error message.
+    exitcode : int
+        Exit code.
+    """
+
     proc = subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
@@ -27,7 +45,7 @@ def test_start_workspace():
     """
     Test `teachopencadd start` (exit code, stdout, and stderr) for existing user-defined workspace
     - Run #1: Talktorials do not exist, yet, and are therefore copied
-    - Run #2: Talktorials do already exist, and are therefor NOT copied again
+    - Run #2: Talktorials do already exist, and are therefore NOT copied again
     - Check if number of copied files equals number of files in repository
     - At the end: Remove talktorial copy
     """
@@ -78,12 +96,8 @@ def test_start_workspace():
     files_list_template = sorted(talktorials_path_template.glob("**/*"))
     files_list_test = sorted(talktorials_path_test.glob("**/*"))
     # Remove checkpoint files that may be present
-    files_list_template = [
-        file for file in files_list_template if "checkpoint" not in str(file)
-    ]
-    files_list_test = [
-        file for file in files_list_test if "checkpoint" not in str(file)
-    ]
+    files_list_template = [file for file in files_list_template if "checkpoint" not in str(file)]
+    files_list_test = [file for file in files_list_test if "checkpoint" not in str(file)]
     # The same number of files?
     assert len(files_list_test) == len(files_list_template)
 
@@ -100,10 +114,8 @@ def test_start_incorrect_workspace():
     out, err, exitcode = capture(command.split())
 
     assert exitcode == 1
-    # Keep console output without the trailing "\n"
-    out_template = (_greeting_string() + "\n").encode()
-    assert out == out_template
+    assert out == (_greeting_string() + "\n").encode()
     # Keep console error without traceback
     err = err.split(b"\n")[-2]
-    err_template = b"RuntimeError: Could not find user-defined location `xxx`"
+    err_template = b"RuntimeError: Could not find user-defined location `xxx`."
     assert err == err_template

--- a/teachopencadd/tests/test_cli.py
+++ b/teachopencadd/tests/test_cli.py
@@ -1,0 +1,109 @@
+"""
+Unit tests for Command Line Interface.
+"""
+
+from pathlib import Path
+import subprocess
+
+from teachopencadd.utils import (
+    _greeting_string,
+    _run_jlab_string,
+    _talktorial_list_string,
+)
+from teachopencadd.cli import TALKTORIAL_FOLDER_NAME
+
+
+def capture(command):
+    proc = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = proc.communicate()
+    return out, err, proc.returncode
+
+
+def test_start_workspace():
+    """
+    Test `teachopencadd start` (exit code, stdout, and stderr) for existing user-defined workspace
+    - Run #1: Talktorials do not exist, yet, and are therefore copied
+    - Run #2: Talktorials do already exist, and are therefor NOT copied again
+    - Check if number of copied files equals number of files in repository
+    - At the end: Remove talktorial copy
+    """
+
+    command = "teachopencadd start ."
+
+    # Start workspace #1
+    out, err, exitcode = capture(command.split())
+    # Check exit code, stdout, and stderr
+    assert exitcode == 0
+    assert (
+        out
+        == (
+            _greeting_string()
+            + "\n"
+            + _talktorial_list_string(TALKTORIAL_FOLDER_NAME)
+            + "\n"
+            + _run_jlab_string(TALKTORIAL_FOLDER_NAME)
+            + "\n"
+        ).encode()
+    )
+    assert err == b""
+
+    # Start workspace #2 (this time the talktorial folder already exists)
+    out, err, exitcode = capture(command.split())
+    # Check exit code, stdout, and stderr
+    assert exitcode == 0
+    assert (
+        out
+        == (
+            _greeting_string()
+            + "\n"
+            + f"Workspace exists already at location {TALKTORIAL_FOLDER_NAME}."
+            + "\n"
+            + _talktorial_list_string(TALKTORIAL_FOLDER_NAME)
+            + "\n"
+            + _run_jlab_string(TALKTORIAL_FOLDER_NAME)
+            + "\n"
+        ).encode()
+    )
+    assert err == b""
+
+    # Check if all files were transferred to workspace
+    # Set path to template (repository) and test (copy) talktorial directories
+    talktorials_path_template = Path(__name__).parent / "teachopencadd/talktorials"
+    talktorials_path_test = Path(TALKTORIAL_FOLDER_NAME)
+    # Fetch all files in directories
+    files_list_template = sorted(talktorials_path_template.glob("**/*"))
+    files_list_test = sorted(talktorials_path_test.glob("**/*"))
+    # Remove checkpoint files that may be present
+    files_list_template = [
+        file for file in files_list_template if "checkpoint" not in str(file)
+    ]
+    files_list_test = [
+        file for file in files_list_test if "checkpoint" not in str(file)
+    ]
+    # The same number of files?
+    assert len(files_list_test) == len(files_list_template)
+
+    # At the very end: Delete TeachOpenCADD talktorial folder
+    subprocess.run(f"rm -r {TALKTORIAL_FOLDER_NAME}".split())
+
+
+def test_start_incorrect_workspace():
+    """
+    Test `teachopencadd start` for non-existing user-defined workspace.
+    """
+
+    command = "teachopencadd start xxx"
+    out, err, exitcode = capture(command.split())
+
+    assert exitcode == 1
+    # Keep console output without the trailing "\n"
+    out_template = (_greeting_string() + "\n").encode()
+    assert out == out_template
+    # Keep console error without traceback
+    err = err.split(b"\n")[-2]
+    err_template = b"RuntimeError: Could not find user-defined location `xxx`"
+    assert err == err_template

--- a/teachopencadd/utils.py
+++ b/teachopencadd/utils.py
@@ -3,6 +3,7 @@ Helper functions and constants for the TeachOpenCADD talktorials
 """
 
 from pathlib import Path
+import sys
 
 from . import _version
 
@@ -127,6 +128,5 @@ def _talktorial_list_string(talktorials_dst_dir):
         message = "\n".join(message)
         return message
     else:
-        raise RuntimeError(
-            f"Could not find talktorials at expected location `{talktorials_dst_dir}`"
-        )
+        print(f"Could not find talktorials at expected location `{talktorials_dst_dir}`")
+        sys.exit()

--- a/teachopencadd/utils.py
+++ b/teachopencadd/utils.py
@@ -2,6 +2,10 @@
 Helper functions and constants for the TeachOpenCADD talktorials
 """
 
+from pathlib import Path
+
+from . import _version
+
 
 def seed_everything(seed=22):
     """Set the RNG seed in Python and Numpy"""
@@ -13,8 +17,9 @@ def seed_everything(seed=22):
     os.environ["PYTHONHASHSEED"] = str(seed)
     np.random.seed(seed)
 
+
 def show_pdf(pdf_url):
-    """ PDF viewer in notebook
+    """PDF viewer in notebook
 
     Parameters
     ----------
@@ -24,8 +29,7 @@ def show_pdf(pdf_url):
     -----
     You might need to click "File> Trust this notebook for this live PDF preview to work".
     """
-    import requests
-    from IPython.display import HTML
+    from IPython.display import display, HTML
 
     display(
         HTML(
@@ -38,8 +42,9 @@ def show_pdf(pdf_url):
         )
     )
 
+
 def pdbqt_to_pdbblock(pdbqt):
-    """ File converter
+    """File converter
 
     Parameters
     ----------
@@ -53,3 +58,75 @@ def pdbqt_to_pdbblock(pdbqt):
             if line[:6] in ("ATOM  ", "HETATM"):
                 lines.append(line[:67].strip())
     return "\n".join(lines)
+
+
+def _greeting_string():
+    """
+    Print TeachOpenCADD greeting.
+
+    Notes
+    -----
+    Generated with https://manytools.org/hacker-tools/ascii-banner/ (Font: Mini)
+    """
+
+    message = f"""
+ ___                _               _       _   _  
+  |  _   _.  _ |_  / \ ._   _  ._  /   /\  | \ | \ 
+  | (/_ (_| (_ | | \_/ |_) (/_ | | \_ /--\ |_/ |_/ 
+                       |                           
+
+    version {_version.get_versions()['version']}
+    by @volkamerlab
+    """
+
+    return message
+
+
+def _run_jlab_string(talktorials_dst_dir):
+    """
+    Print command for starting JupyterLab from workspace folder.
+
+    Parameters
+    ----------
+    talktorials_dst_dir : str or pathlib.Path
+        Path to directory containing the talktorial folders.
+    """
+
+    talktorials_dst_dir = Path(talktorials_dst_dir)
+
+    message = f"""
+To start working with the talktorials in JupyterLab run:
+
+    jupyter lab {talktorials_dst_dir}
+
+Enjoy!
+"""
+
+    return message
+
+
+def _talktorial_list_string(talktorials_dst_dir):
+    """
+    Print a list of all talktorials.
+
+    Parameters
+    ----------
+    talktorials_dst_dir : str or pathlib.Path
+        Path to directory containing the talktorial folders.
+    """
+
+    talktorials_dst_dir = Path(talktorials_dst_dir)
+
+    message = []
+
+    if talktorials_dst_dir.is_dir():
+        message.append("\nTalktorials available in your workspace:\n")
+        for d in sorted(talktorials_dst_dir.glob("**/*")):
+            if (d / "talktorial.ipynb").exists():
+                message.append(f"  - {d.name}")
+        message = "\n".join(message)
+        return message
+    else:
+        raise RuntimeError(
+            f"Could not find talktorials at expected location `{talktorials_dst_dir}`"
+        )


### PR DESCRIPTION
## Description
Add `teachopencadd start workspace` CLI that copies talktorials from their location in the `teachopencadd` package to a user-defined folder (**workspace**).

## CLI Behavior
`teachopencadd start .` will copy the [full talktorial folder content](https://github.com/volkamerlab/teachopencadd/tree/master/teachopencadd/talktorials) to a folder called `teachopencadd-talktorials`, which lives in the user-defined workspace (here: working directory `.`)

### Workspace exists and does not contain a `teachopencadd-talktorials` folder, yet
Copy files, list talktorials, give JLab instructions.

```
$ teachopencadd start ~/workspaces

 ___                _               _       _   _  
  |  _   _.  _ |_  / \ ._   _  ._  /   /\  | \ | \ 
  | (/_ (_| (_ | | \_/ |_) (/_ | | \_ /--\ |_/ |_/ 
                       |                           

    version v1.3.0+705.g394f25c
    by @volkamerlab
    

Talktorials available in your workspace:

  - T000_template
  - T001_query_chembl
  - T002_compound_adme
  - T003_compound_unwanted_substructures
  - T004_compound_similarity
  - T005_compound_clustering
  - T006_compound_maximum_common_substructures
  - T007_compound_activity_machine_learning
  - T008_query_pdb
  - T009_compound_ensemble_pharmacophores
  - T010_binding_site_comparison
  - T011_query_online_api_webservices
  - T012_query_klifs
  - T013_query_pubchem
  - T014_binding_site_detection
  - T015_protein_ligand_docking
  - T016_protein_ligand_interactions
  - T017_advanced_nglview_usage
  - T019_md_simulation
  - T020_md_analysis
  - T021_one_hot_encoding
  - T022_ligand_based_screening_neural_network

To start working with the talktorials in JupyterLab run:

    jupyter lab /home/dominique/workspaces/teachopencadd-talktorials

Enjoy!
```

### Workspace exists but contains already a `teachopencadd-talktorials` folder
Inform user that folder already exists, do not overwrite folder, list talktorials, give JLab instructions.

```
$ teachopencadd start ~/workspaces

 ___                _               _       _   _  
  |  _   _.  _ |_  / \ ._   _  ._  /   /\  | \ | \ 
  | (/_ (_| (_ | | \_/ |_) (/_ | | \_ /--\ |_/ |_/ 
                       |                           

    version v1.3.0+703.gc3a6308.dirty
    by @volkamerlab
    
Workspace exists already at location /home/dominique/workspaces/teachopencadd-talktorials.

Talktorials available in your workspace:

  - T000_template
  - T001_query_chembl
  - T002_compound_adme
  - T003_compound_unwanted_substructures
  - T004_compound_similarity
  - T005_compound_clustering
  - T006_compound_maximum_common_substructures
  - T007_compound_activity_machine_learning
  - T008_query_pdb
  - T009_compound_ensemble_pharmacophores
  - T010_binding_site_comparison
  - T011_query_online_api_webservices
  - T012_query_klifs
  - T013_query_pubchem
  - T014_binding_site_detection
  - T015_protein_ligand_docking
  - T016_protein_ligand_interactions
  - T017_advanced_nglview_usage
  - T019_md_simulation
  - T020_md_analysis
  - T021_one_hot_encoding
  - T022_ligand_based_screening_neural_network

To start working with the talktorials in JupyterLab run:

    jupyter lab /home/dominique/workspaces/teachopencadd-talktorials

Enjoy!
```

### Workspace does not exist
Inform user about invalid workspace location, do nothing more.

```
$ teachopencadd start ~/xxx

 ___                _               _       _   _  
  |  _   _.  _ |_  / \ ._   _  ._  /   /\  | \ | \ 
  | (/_ (_| (_ | | \_/ |_) (/_ | | \_ /--\ |_/ |_/ 
                       |                           

    version v1.3.0+705.g394f25c
    by @volkamerlab
    
Could not find user-defined location `/home/dominique/xxx`
```

## Todos
- [x] Implement behavior as shown above
- [x] Implement tests (test exit code, stdout, stderr, number of copied files)
  - [x] Workspace exists, talktorials not there yet 
  - [x] Workspace exists, talktorials already there
  - [x] Workspace does not exist
  - [x] Test JupyterLab command as well?
- [x] Add `pytest-cov` to report code coverage (do not enable CodeCov since most testing is done via `nbval`)

## Question
- [x] Should be remove the Traceback from the last case? Using only `print` instead of `raise` in combo with `sys.exit`?
- [x] Use `logging` instead of `print` - or print ok here?

## Status
- [x] Ready to go