### PR TITLE
Fix CLI bug (greeting printed twice)

### DIFF
--- a/teachopencadd/cli.py
+++ b/teachopencadd/cli.py
@@ -20,8 +20,6 @@ def main():
     - teachopencadd start path/to/workspace
     """
 
-    print(_greeting_string())
-
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
 
@@ -63,6 +61,8 @@ def _start(args):
     - print list of talktorials in workspace
     - print instructions on how to fire up the talktorials in JupyterLab
     """
+
+    print(_greeting_string())
 
     # Source and destination directories for talktorials
     talktorials_src_dir = Path(_version.__file__).parent / "talktorials"

--- a/teachopencadd/tests/test_cli.py
+++ b/teachopencadd/tests/test_cli.py
@@ -122,3 +122,19 @@ def test_jlab_import():
             "JupyterLab cannot be imported; install with `mamba install jupyterlab`.",
             ImportWarning,
         )
+
+
+def test_incomplete_signature():
+    """
+    Test behavior when the user enters an incomplete CLI command.
+    """
+
+    command = "teachopencadd"
+    out, err, exitcode = capture(command.split())
+
+    assert exitcode == 0
+    # Since the output will change whenever new subcommands are added to the CLI,
+    # Check only the beginning and end of the message, which will stay the same.
+    assert out.startswith("usage")
+    assert out.endswith("show this help message and exit\n")
+    assert not err


### PR DESCRIPTION
## Description
The TeachOpenCADD greeting is printed twice when using `teachopencadd` or `teachopencadd -h`. Remove the greeting in these instances (easier than reducing the output to one greeting).

## Todos
- [x] Fix CLI greeting bug (printed doubled) for `teachopencadd -h`
- [x] Add test

## Questions
None.

## Status
- [x] Ready to go