### PR TITLE
Add `defaults` conda channel (needed for installations under Windows)

### DIFF
--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -1,6 +1,7 @@
 ﻿name: teachopencadd
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python>=3.7
   - pip

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -12,7 +12,11 @@ Install from the conda package
 
 1. Create a new conda environment for TeachOpenCADD::
 
+    # Linux / MacOS
     mamba install teachopencadd
+
+    # Windows
+    mamba install teachopencadd -c conda-forge -c defaults
 
 2. Activate the new environment::
 


### PR DESCRIPTION
## Description
Under Windows, we cannot install `tensorflow >=2` via conda-forge. We need to add the `defaults` channel.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Add `defaults` channel to
  - [x] environment file [here](https://github.com/volkamerlab/teachopencadd/blob/ds-conda-forge/devtools/test_env.yml)
  - [x] installation description via `teachopencadd` conda package: `mamba install teachopencadd -c conda-forge -c defaults` [here](https://projects.volkamerlab.org/teachopencadd/installing.html)

## Questions
None.

## Status
- [x] Ready to go