### PR TITLE
Add opengraph to test env + docs conf.py

### DIFF
--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -55,6 +55,7 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx-copybutton
   - sphinx-gallery
+  - sphinxext-opengraph
   - autodocsumm
   - pip:
       - black-nb

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -55,10 +55,10 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx-copybutton
   - sphinx-gallery
-  - sphinxext-opengraph
   - autodocsumm
   - pip:
       - black-nb
       - nbsphinx-link
+      - sphinxext-opengraph
       # TeachOpenCADD itself
       - ../

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,7 @@ extensions = [
     "nbsphinx_link",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinx_copybutton",
+    "sphinxext.opengraph",
 ]
 
 autosummary_generate = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -221,3 +221,11 @@ html_css_files = [
     "custom.css",
 ]
 html_js_files = []
+
+
+# -- Extension for opengraph -------------------------------------------------
+
+ogp_site_url = "https://projects.volkamerlab.org/teachopencadd/"
+ogp_image = "https://github.com/volkamerlab/teachopencadd/blob/master/docs/_static/images/TeachOpenCADD_topics.svg"
+ogp_description_length = 300
+ogp_type = "website"


### PR DESCRIPTION
## Description
Add the `opengraph` sphinx extension to render previews when we post our website's link. 

https://github.com/wpilibsuite/sphinxext-opengraph

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Add `opengraph` to test env (pip install)
- [x] Add extension to docs `conf.py`
- [x] Define options: https://github.com/wpilibsuite/sphinxext-opengraph#options

## Questions
None.

## Status
- [x] Ready to go