### PR TITLE
Update opengraph image URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,6 +226,6 @@ html_js_files = []
 # -- Extension for opengraph -------------------------------------------------
 
 ogp_site_url = "https://projects.volkamerlab.org/teachopencadd/"
-ogp_image = "https://github.com/volkamerlab/teachopencadd/blob/master/docs/_static/images/TeachOpenCADD_topics.png"
+ogp_image = "https://raw.githubusercontent.com/volkamerlab/teachopencadd/master/docs/_static/images/TeachOpenCADD_topics.png"
 ogp_description_length = 300
 ogp_type = "website"


### PR DESCRIPTION
## Description
Update opengraph image URL since image is not shown in website preview! 

I think we need the raw URL path:
https://raw.githubusercontent.com/volkamerlab/teachopencadd/master/docs/_static/images/TeachOpenCADD_topics.png

## Todos
- [x] Update opengraph image URL

## Questions
None.

## Status
- [x] Ready to go