### PR TITLE
Update installation instructions

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -29,9 +29,10 @@ Install from the conda package
 Install from the latest development snapshot
 --------------------------------------------
 
-1. Create a new conda environment::
+1. Create a new conda environment and activate it::
 
     mamba env create -f https://raw.githubusercontent.com/volkamerlab/TeachOpenCADD/master/devtools/test_env.yml
+    conda activate teachopencadd
 
 2. Download a zipfile of the repository using `this link <https://github.com/volkamerlab/teachopencadd/archive/master.zip>`_.
 3. Unzip to your location of choice.

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -13,10 +13,10 @@ Install from the conda package
 1. Create a new conda environment for TeachOpenCADD::
 
     # Linux / MacOS
-    mamba install teachopencadd
+    mamba create -n teachopencadd teachopencadd
 
     # Windows
-    mamba install teachopencadd -c conda-forge -c defaults
+    mamba create -n teachopencadd teachopencadd -c conda-forge -c defaults
 
 2. Activate the new environment::
 


### PR DESCRIPTION
## Description
Update installation instructions; see user experience by @magattaca:
https://magattaca.hatenablog.com/entry/2021/12/31/003600

## Todos
- [x] Via `conda` package: Create new environment (currently only installs the package without new env): Change `mamba install teachopencadd` to `mamba create -n teachopencadd teachopencadd`
- [x] Via GitHub dev snapshot: Do not forget to activate the `conda` environment!

## Status
- [x] Ready to go