### PR TITLE
Fixes for protonation of protein and binding site detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.cfg.python-version }}
+          mamba-version: "*"
           activate-environment: teachopencadd
           channel-priority: true
           environment-file: devtools/test_env.yml

--- a/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/binding_site_detection.py
+++ b/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/binding_site_detection.py
@@ -50,7 +50,7 @@ class BindingSiteDetection:
         # call the function
         definition_method(protein_obj, binding_site_specs_obj, binding_site_output_path)
 
-    def compute_by_coordinates(self, protein_obj, binding_site_specs_obj):
+    def compute_by_coordinates(self, protein_obj, binding_site_specs_obj, binding_site_output_path=None):
         """
         Extract the binding site coordinates specified in input specifications. 
         The function is called when binding site definition method is `coordinates`.

--- a/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/helpers/nglview.py
+++ b/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/helpers/nglview.py
@@ -133,7 +133,7 @@ def docking(
 
     # Create viewer widget
     viewer = nv.NGLWidget(height="860px")
-    
+
     protein_filepath = Path(protein_filepath)
     with open(protein_filepath) as f:
         viewer.add_component(f, ext=protein_filepath.suffix.strip("."))
@@ -273,7 +273,7 @@ def interactions(
     )
 
     protein_filepath = Path(protein_filepath)
-    
+
     # This is the event handler - action taken when the user clicks on the selection box
     # We need to define it here so it can "see" the viewer variable
     def _on_selection_change(change):
@@ -284,7 +284,7 @@ def interactions(
 
             # NGL Viewer
             app.center = viewer = nv.NGLWidget(height="860px", default=True, gui=True)
-            
+
             with open(protein_filepath) as f:
                 prot_component = viewer.add_component(
                     f, ext=protein_filepath.suffix.strip("."), default_representation=False
@@ -298,8 +298,10 @@ def interactions(
                 showBackground=True,
                 backgroundColor="black",
             )
-            
-            list_docking_poses_filepaths[change["new"]] = Path(list_docking_poses_filepaths[change["new"]])
+
+            list_docking_poses_filepaths[change["new"]] = Path(
+                list_docking_poses_filepaths[change["new"]]
+            )
             with open(list_docking_poses_filepaths[change["new"]]) as f:
                 lig_component = viewer.add_component(
                     f, ext=list_docking_poses_filepaths[change["new"]].suffix.strip(".")
@@ -312,6 +314,17 @@ def interactions(
 
             # Add interactions
             interactions = list_docking_poses_plip_dicts[change["new"]]
+            # TODO interactions should be a dict
+            # Under Python 3.9 this dict is embedded in a list
+            # Temporary workaround: Get dict out of that list
+            if isinstance(interactions, list):
+                if len(interactions) == 1:
+                    interactions = interactions[0]
+                else:
+                    raise ValueError(
+                        f"Contact TeachOpenCADD maintainers "
+                        f"to check the temporary workaround on the interactions dict/list."
+                    )
 
             interacting_residues = []
 

--- a/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/helpers/obabel.py
+++ b/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/helpers/obabel.py
@@ -45,10 +45,10 @@ def optimize_structure_for_docking(
         The structure object is optimized in place.
     """
 
-    if add_hydrogens:
-        pybel_structure_object.addh()
     if protonate_for_pH:
         pybel_structure_object.OBMol.CorrectForPH(protonate_for_pH)
+    if add_hydrogens:
+        pybel_structure_object.addh()
     if generate_3d_structure:
         pybel_structure_object.make3D(forcefield="mmff94s", steps=10000)
     if calculate_partial_charges:


### PR DESCRIPTION
## Description
Small fixes for T018 pipeline issues and CI Python 3.9 issues. 

## TODOs
- [x] commands in obabel helper function are run in the wrong order and result in docking to a structure that has no hydrogens
- [x] issue with number of positional arguments when running binding site detection class.
- [ ] Under Python 3.9: Check if ´interactions´ variable is dict or a dict embedded in list (Python 3.9) - make sure we work with the dict. See [error message](https://github.com/volkamerlab/teachopencadd/runs/5461111349?check_suite_focus=true#step:8:163).

## Status
- [ ] Ready to go