### PR TITLE
Pin jinja2 to fix failing docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           cd docs
           make clean
-          SPHINXOPTS="-j2 -W -T --keep-going" make html
+          SPHINXOPTS="-j2 -T --keep-going" make html
           # Extra UGLY patch to fix PDF IFrame on T005
           cp talktorials/images/*.pdf _build/html/_images/
           sed -i 's|src="images/butina_full.pdf"|src="../_images/butina_full.pdf"|g' \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: "3.7"
+          mamba-version: "*"
           activate-environment: teachopencadd
           channel-priority: true
           environment-file: devtools/test_env.yml

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A teaching platform for computer-aided drug design (CADD) using open source pack
 [![DOI](https://img.shields.io/badge/DOI-10.1186%2Fs13321--019--0351--x-blue.svg)](https://doi.org/10.1186/s13321-019-0351-x)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2600909.svg)](https://doi.org/10.5281/zenodo.2600909)
 
+<!-- markdown-link-check-disable-next-line -->
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/volkamerlab/TeachOpenCADD/master)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 ![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/volkamerlab/teachopencadd)
@@ -47,12 +48,14 @@ For each topic, an interactive Jupyter Notebook is offered, using open source pa
 ## Get started
 
 [![GH Actions Docs](https://github.com/volkamerlab/teachopencadd/workflows/Docs/badge.svg)](https://projects.volkamerlab.org/teachopencadd/)
+<!-- markdown-link-check-disable-next-line -->
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/volkamerlab/TeachOpenCADD/master)
 
 If you can't wait and just want to read through the materials, please go to the read-only version [here](https://projects.volkamerlab.org/teachopencadd/talktorials.html).
 
 If you'd like to execute the provided notebooks, we offer two possibilities:
 
+<!-- markdown-link-check-disable-next-line -->
 - Online thanks to [Binder](https://mybinder.org/). This takes around 10 minutes to get ready, but does not require any kind of setup on your end. Click here to get started: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/volkamerlab/TeachOpenCADD/master). Once it has loaded, you can navigate to `teachopencadd/talktorials/` to find the executable notebooks.
 - Locally using our `conda` package. More details in this [section of the documentation](https://projects.volkamerlab.org/teachopencadd/installing.html).
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ For each topic, an interactive Jupyter Notebook is offered, using open source pa
 
 ## Get started
 
+<!-- markdown-link-check-disable -->
 [![GH Actions Docs](https://github.com/volkamerlab/teachopencadd/workflows/Docs/badge.svg)](https://projects.volkamerlab.org/teachopencadd/)
-<!-- markdown-link-check-disable-next-line -->
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/volkamerlab/TeachOpenCADD/master)
+<!-- markdown-link-check-enable -->
 
 If you can't wait and just want to read through the materials, please go to the read-only version [here](https://projects.volkamerlab.org/teachopencadd/talktorials.html).
 

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -48,6 +48,8 @@ dependencies:
   - pytest-cov
   - nbval
   - shyaml
+  # Workaround for https://github.com/sphinx-doc/sphinx/issues/10289
+  - jinja2==3.0.3
   ## Docs
   - sphinx
   - sphinx-material


### PR DESCRIPTION
## Description
Pin jinja2 to fix failing docs:
https://github.com/volkamerlab/teachopencadd/runs/5686402020?check_suite_focus=true#step:8:42

## Todos
- [x] Pin jinja2
- [x] Use mamba as resolver in docs CI
- [x] Do not convert warnings into errors (remove -W from SPHINXOPTS, see [here](https://github.com/volkamerlab/teachopencadd/pull/217/commits/8121c83b79419a4813b0d185b37381c6b4639c84)): https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-W
- [x] README links broken - Binder instances: Add `<!-- markdown-link-check-disable-next-line -->` as described here: https://github.com/gaurav-nelson/github-action-markdown-link-check#disable-check-for-some-links

## Status
Note: In this PR, only the docs CI needs to pass.
- [ ] Ready to go