### PR TITLE
Fix CI failures

### DIFF
--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -27,7 +27,7 @@ dependencies:
   - pypdb
   - biopython<=1.77
   - biopandas
-  - rdkit<=2021.09.2
+  - rdkit
   - openbabel
   - opencadd
   - biotite


### PR DESCRIPTION
## Description
This PR aims to fix CI failures involving RDKit installation on MacOS and T018 with failing API request of DogSiteScorer.

## Todos
- [ ] fix RDKit installation on MacOS
- [ ] fix T018 with failing API requests of DogSiteScorer

## Status
- [ ] Ready to go