### PR TITLE
Test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,10 @@ jobs:
         shell: bash -l {0}
         run: |
           PYTEST_ARGS="-v --nbval-lax --current-env --dist loadscope -n auto"
-          if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb -k 'not T018'
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
           else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ -k 'not T018 and not T019'
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ -k 'not T019'
           fi
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,9 @@ jobs:
         run: |
           PYTEST_ARGS="-v --nbval-lax --current-env --dist loadscope -n auto"
           if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb --ignore-glob=teachopencadd/talktorials/T018*
+            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb -k 'not T018'
           else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ --ignore-glob=teachopencadd/talktorials/T018* --ignore-glob=teachopencadd/talktorials/T019*
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ -k 'not T018 and not T019'
           fi
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --current-env --dist loadfile -n auto"
+          PYTEST_ARGS="--nbval-lax --current-env --dist loadscope -n auto"
           if [ "$RUNNER_OS" != "Windows" ]; then
             pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,17 @@ jobs:
       matrix:
         cfg:
           - os: ubuntu-latest
-            python-version: "3.7"
+            python-version: "3.8"
           - os: ubuntu-latest
             python-version: "3.9"
           - os: macos-latest
-            python-version: "3.7"
+            python-version: "3.8"
           - os: macos-latest
             python-version: "3.9"
           - os: windows-latest
-            python-version: "3.7"
+            python-version: "3.8"
+          - os: windows-latest
+            python-version: "3.9"
 
     env:
       PYVER: ${{ matrix.cfg.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --current-env"
+          PYTEST_ARGS="--nbval-lax --current-env --dist loadfile -n auto"
           if [ "$RUNNER_OS" != "Windows" ]; then
             pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
             python-version: "3.9"
           - os: macos-latest
             python-version: "3.7"
+          - os: macos-latest
+            python-version: "3.9"
           - os: windows-latest
             python-version: "3.7"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --current-env --dist loadscope"
+          PYTEST_ARGS="--nbval-lax --current-env"
           if [ "$RUNNER_OS" != "Windows" ]; then
             pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --current-env --dist loadscope -n auto"
+          PYTEST_ARGS="-v --nbval-lax --current-env --dist loadscope -n auto"
           if [ "$RUNNER_OS" != "Windows" ]; then
             pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb --ignore-glob=teachopencadd/talktorials/T018*
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,13 @@ jobs:
       matrix:
         cfg:
           - os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.7"
           - os: ubuntu-latest
             python-version: "3.9"
           - os: macos-latest
-            python-version: "3.8"
-          - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.7"
           - os: windows-latest
-            python-version: "3.8"
-          - os: windows-latest
-            python-version: "3.9"
+            python-version: "3.7"
 
     env:
       PYVER: ${{ matrix.cfg.python-version }}
@@ -79,9 +75,9 @@ jobs:
         run: |
           PYTEST_ARGS="--nbval-lax --current-env --dist loadscope -n auto"
           if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
+            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb --ignore-glob=teachopencadd/talktorials/T018*
           else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ --ignore-glob=teachopencadd/talktorials/T019*
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ --ignore-glob=teachopencadd/talktorials/T018* --ignore-glob=teachopencadd/talktorials/T019*
           fi
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
+          PYTEST_ARGS="--nbval-lax --current-env --dist loadscope"
           if [ "$RUNNER_OS" != "Windows" ]; then
             pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
           else

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           mamba-version: "*"
           activate-environment: teachopencadd
           channel-priority: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: "3.8"
+          python-version: "3.7"
           mamba-version: "*"
           activate-environment: teachopencadd
           channel-priority: true

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.8
+  - python>=3.7
   - pip
   - jupyter
   - jupyterlab>=3
@@ -59,8 +59,6 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery
   - autodocsumm
-  ## temporary fix for rdkit on MacOS
-  - fontconfig==2.13.1
   - pip:
       - black-nb
       - nbsphinx-link

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -13,7 +13,6 @@ dependencies:
   - numpy
   - scikit-learn
   - tensorflow>=2.0
-  - h5py<3.0.0
   - seaborn
   - matplotlib-venn
   # Remove jsonschema once this issue is fixed: https://github.com/Yelp/bravado/issues/478
@@ -60,8 +59,6 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery
   - autodocsumm
-  ## temporary fix for rdkit on MacOS
-  - fontconfig==2.13.1
   - pip:
       - black-nb
       - nbsphinx-link

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -59,6 +59,8 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery
   - autodocsumm
+  ## temporary fix for rdkit on MacOS, https://github.com/conda-forge/fontconfig-feedstock/issues/54
+  - fontconfig==2.13.1
   - pip:
       - black-nb
       - nbsphinx-link

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -27,7 +27,7 @@ dependencies:
   - pypdb
   - biopython<=1.77
   - biopandas
-  - rdkit
+  - rdkit==2021.09.5
   - openbabel
   - opencadd
   - biotite

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -59,6 +59,8 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery
   - autodocsumm
+  ## temporary fix for rdkit on MacOS
+  - fontconfig==2.13.1
   - pip:
       - black-nb
       - nbsphinx-link

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -12,7 +12,7 @@ dependencies:
   # Explicitly add numpy because of https://github.com/volkamerlab/teachopencadd/issues/150
   - numpy
   - scikit-learn
-  - tensorflow>=2.0
+  - tensorflow>2.4
   - seaborn
   - matplotlib-venn
   # Remove jsonschema once this issue is fixed: https://github.com/Yelp/bravado/issues/478

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.7
+  - python>=3.8
   - pip
   - jupyter
   - jupyterlab>=3
@@ -59,10 +59,6 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery
   - autodocsumm
-  ## temporary fix for rdkit on MacOS
-  - fontconfig==2.13.1
-  ## try as fix for dead kernel on MacOS Python 3.7
-  - h5py<3.0.0
   - pip:
       - black-nb
       - nbsphinx-link

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -61,6 +61,8 @@ dependencies:
   - autodocsumm
   ## temporary fix for rdkit on MacOS
   - fontconfig==2.13.1
+  ## try as fix for dead kernel on MacOS Python 3.7
+  - h5py<3.0.0
   - pip:
       - black-nb
       - nbsphinx-link


### PR DESCRIPTION
## Description
We recently discovered inconsistent results between different runs of the CI. This PR will try to get consistent behavior.

## Attempts
- remove pinning of fontconfig & h5py, single process for nbval
  - attempt 1:
    - Linux 3.7 got stuck in T019
    - Linux 3.9 succeeded
    - MacOS 3.7 import failure in cell 3 of T019, nb kernel dies in T020
    - Windows 3.7 succeeded
  - attempt 2:
    - Linux 3.7 succeeded
    - Linux 3.9 succeeded
    - MacOS 3.7 import failure in cell 3 of T019, nb kernel dies in T020
    - Windows 3.7 succeeded
- remove pinning of fontconfig & h5py, multiple process for nbval (--dist loadfile -n auto)
  - attempt 1:
    - Linux 3.7 succeeded
    - Linux 3.9 succeeded
    - MacOS 3.7 import failure in cell 3 of T019, import failure T018, nb kernel dies in T020
    - Windows 3.7 succeeded
  - attempt 2:
    - Linux 3.7 succeeded
    - Linux 3.9 succeeded
    - MacOS 3.7 import failure in cell 3 of T019, import failure T018, nb kernel dies in T020
    - Windows 3.7 succeeded
- remove pinning of fontconfig & h5py, multiple process for nbval (--dist loadscope -n auto)
  - attempt 1:
    - Linux 3.7 succeeded
    - Linux 3.9 succeeded
    - MacOS 3.7 import failure in cell 3 of T019, import failure T018, nb kernel dies in T020
    - Windows 3.7 succeeded
  - attempt 2:
    - Linux 3.7 succeeded
    - Linux 3.9 succeeded
    - MacOS 3.7 import failure in cell 3 of T019, import failure T018, nb kernel dies in T020
    - MacOS 3.9 fontconfig error
    - Windows 3.7 succeeded
- removing, pinning of h5py multiple process for nbval (--dist loadscope -n auto)
  - attempt 1:
    - Linux 3.7 connection error T011
    - Linux 3.9 url errors T017, T018
    - MacOS 3.7 import failure in cell 3 of T019, import failure T018, nb kernel dies in T020
    - MacOS 3.9 succeeded
    - Windows 3.7 succeeded
- initial pinning, multiple process for nbval (--dist loadscope -n auto)
  - attempt 1:
    - Linux 3.7 succeeded
    - Linux 3.9 succeeded
    - MacOS 3.7 T019 antechamber not installed (dependency of openff toolkit), T018 smina with sigkill
    - MacOS 3.9 succeeded
    - Windows 3.7 mamba installation error
  - attempt 2 (only failed runs):
    - MacOS 3.7 T019 antechamber not installed (dependency of openff toolkit)
    - Windows 3.7 succeeded
  - attempt 3 (only failed runs):
    -  MacOS 3.7 T019 antechamber not installed (dependency of openff toolkit), T018 smina with sigkill
- remove pinning of fontconfig & h5py, multiple process for nbval (--dist loadscope -n auto), drop python 3.7
  - attemps 1:
    - Linux 3.8 succeeded
    - Linux 3.9 urlopen error T017
    - MacOS 3.8 fontconfig error
    - MacOS 3.9 fontconfig error
    - Windows 3.8
    - Windows 3.9
- remove pinning h5py, multiple process for nbval (--dist loadscope -n auto), drop python 3.7
  - attemp 1:
    - Linux 3.8 succeeded
    - Linux 3.9 succeeded
    - MacOS 3.8 succeeded
    - MacOS 3.9 succeeded
    - Windows 3.8 failing T018 and T024 due to pytest plugin exception: [WinError 10055] An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full
    - Windows 3.9 failing T018 and T024 due to pytest plugin exception: [WinError 10055] An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full
  - attempt 2 (only failed tests):
    - Windows 3.8 failing T018 due to pytest plugin exception: [WinError 10055] An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full
    - Windows 3.9 failing T018 due to pytest plugin exception: [WinError 10055] An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full
- remove pinning fontconfig and h5py, multiple processes for nbval (--dist loadscope -n auto), skip T018 for all and T019 for windows
  - attempt 1:
    - Linux 3.7 succeeded
    - Linux 3.9 succeeded
    - MacOS 3.7 antechamber error in T019
    - Windows 3.7 succeeded
- remove pinning fontconfig and h5py, multiple processes for nbval (--dist loadscope -n auto), test T019 only on linux
  - attempt 1:
    - Linux 3.7 urlopen error in T017
    - Linux 3.9 succeeded
    - MacOS 3.7 h5py error in T022
    - Windows succeeded
- remove pinning fontconfig and h5py, pinning tensorflow, multiple processes for nbval (--dist loadscope -n auto), test T019 only on linux
  - attempt 1:
    - Linux 3.7 urlopen error To17 and T018
    - Linux 3.9 succeeded
    - MacOS 3.7 fontconfig error
    - Windows succeeded
- remove pinning for h5py, pinning tensorflow, multiple processes for nbval (--dist loadscope -n auto), test T019 only on linux
  - attempt 1:
    - Linux 3.7 succeeded
    - Linux 3.9 succeeded
    - MacOS 3.7 succeeded
    - Windows succeeded
  - attempt 2:
    - Linux 3.7 kekulize error T006
    - Linux 3.9 kekulize error T006, connectionerror T008, index error T009 (based on T008)
    - MacOS 3.7 kekulize error T006
    - Windows kekulize error T006
 - remove pinning for h5py, pinning tensorflow & rdkit, multiple processes for nbval (--dist loadscope -n auto), test T019 only on linux
  - attempt 1:
    - Linux 3.7 succeeded
    - Linux 3.9 succeeded
    - MacOS 3.7 succeeded
    - Windows succeeded
  - attempt 2:
    - Linux 3.7 succeeded
    - Linux 3.9 urlopen T017
    - MacOS 3.7 succeeded
    - Windows succeeded

## Status
- [ ] Ready to go