### PR TITLE
Pin rdkit to fix kekulize error

### DIFF
--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -28,7 +28,7 @@ dependencies:
   - pypdb
   - biopython<=1.77
   - biopandas
-  - rdkit
+  - rdkit==2021.09.5
   - openbabel
   - opencadd
   - biotite


### PR DESCRIPTION
## Description
This PR fixes the RDKit kekulize error by pinning RDKit.

## Todos
- [x] pin RDKit to 2021.09.5
- [x] tests pass

## Status
- [x] Ready to go