### PR TITLE
Fix black-nb in T019

### DIFF
--- a/teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb
+++ b/teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb
@@ -634,15 +634,15 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "tags": [
-     "nbsphinx-thumbnail"
-    ],
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 217
     },
     "id": "04v75eTlcEtx",
-    "outputId": "800d782f-8e3c-40c7-bd2d-3339fc8e8b54"
+    "outputId": "800d782f-8e3c-40c7-bd2d-3339fc8e8b54",
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
    },
    "outputs": [
     {


### PR DESCRIPTION
## Description
T019 wasn't satisfying `black-nb`, addressed in #240 .

## Todos
- [x] Fix failing CI. Given that the broken link that creates failing docs is address in #238 , this PR accomplishes its goal.


## Status
- [x] Ready to go