### PR TITLE
Python requirements >= 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-          #- os: ubuntu-latest
-          #  python-version: "3.8"
-          #- os: ubuntu-latest
-          #  python-version: "3.9"
-          #- os: macos-latest
-          #  python-version: "3.8"
+          - os: ubuntu-latest
+            python-version: "3.8"
+          - os: ubuntu-latest
+            python-version: "3.9"
+          - os: macos-latest
+            python-version: "3.8"
           - os: windows-latest
             python-version: "3.9"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           python-version: ${{ matrix.cfg.python-version }}
           mamba-version: "*"
+          # Uncomment next line if you are running the tests locally via https://github.com/nektos/act
+          #miniconda-version: "latest"
           activate-environment: teachopencadd
           channel-priority: true
           environment-file: devtools/test_env.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         cfg:
           - os: ubuntu-latest
-            python-version: "3.7"
+            python-version: "3.8"
           - os: ubuntu-latest
             python-version: "3.9"
           - os: macos-latest
-            python-version: "3.7"
+            python-version: "3.8"
           - os: windows-latest
-            python-version: "3.7"
+            python-version: "3.8"
 
     env:
       PYVER: ${{ matrix.cfg.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,14 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-          - os: ubuntu-latest
-            python-version: "3.8"
-          - os: ubuntu-latest
-            python-version: "3.9"
-          - os: macos-latest
-            python-version: "3.8"
+          #- os: ubuntu-latest
+          #  python-version: "3.8"
+          #- os: ubuntu-latest
+          #  python-version: "3.9"
+          #- os: macos-latest
+          #  python-version: "3.8"
           - os: windows-latest
-            python-version: "3.8"
+            python-version: "3.9"
 
     env:
       PYVER: ${{ matrix.cfg.python-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           mamba-version: "*"
           activate-environment: teachopencadd
           channel-priority: true

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -13,7 +13,7 @@ dependencies:
   - numpy
   - scikit-learn
   - tensorflow>=2.0
-  - h5py<3.0.0
+  - h5py
   - seaborn
   - matplotlib-venn
   # Remove jsonschema once this issue is fixed: https://github.com/Yelp/bravado/issues/478

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.7
+  - python>=3.8
   - pip
   - jupyter
   - jupyterlab>=3
@@ -31,7 +31,7 @@ dependencies:
   - rdkit==2021.09.5
   - openbabel
   - opencadd
-  - biotite
+  - biotite>=0.34.0
   - smina
   - mdanalysis>=1.0.0
   - mdtraj

--- a/teachopencadd/talktorials/T009_compound_ensemble_pharmacophores/talktorial.ipynb
+++ b/teachopencadd/talktorials/T009_compound_ensemble_pharmacophores/talktorial.ipynb
@@ -1492,7 +1492,6 @@
     }
    ],
    "source": [
-    "# NBVAL_CHECK_OUTPUT\n",
     "k_means = {\n",
     "    \"donors\": clustering(features_coord[\"donors\"], kq),\n",
     "    \"acceptors\": clustering(features_coord[\"acceptors\"], kq),\n",


### PR DESCRIPTION
## Description
Bump up our Python requirements to Python 3.8 (i.e. dropping support for 3.7).
See discussion here: https://github.com/volkamerlab/teachopencadd/issues/252

## Todos
- [x] Pin Python>=3.8 and `biotite`>=0.34.0 in [environment file](https://github.com/volkamerlab/teachopencadd/blob/master/devtools/test_env.yml)
- [x] Update [CI](https://github.com/volkamerlab/teachopencadd/blob/master/.github/workflows/ci.yml) and [docs](https://github.com/volkamerlab/teachopencadd/blob/master/.github/workflows/docs.yml) workflows(move from 3.7 to 3.8)
- [x] Unpin `h5py` (not needed anymore)
- [ ] Mental note: Update `conda` recipe

## Status
- [x] Ready to go