### PR TITLE
CI: Drop figure size `nbval` check

### DIFF
--- a/teachopencadd/talktorials/T025_kinase_similarity_kissim/talktorial.ipynb
+++ b/teachopencadd/talktorials/T025_kinase_similarity_kissim/talktorial.ipynb
@@ -908,8 +908,7 @@
     "ax.set_xlabel(\"Number of structures\")\n",
     "ax.set_ylabel(\"Kinase name\")\n",
     "for i, value in enumerate(n_structures_per_kinase):\n",
-    "    ax.text(value, i, str(value), va=\"center\")\n",
-    "# NBVAL_CHECK_OUTPUT"
+    "    ax.text(value, i, str(value), va=\"center\")"
    ]
   },
   {

--- a/teachopencadd/talktorials/T026_kinase_similarity_ifp/talktorial.ipynb
+++ b/teachopencadd/talktorials/T026_kinase_similarity_ifp/talktorial.ipynb
@@ -895,8 +895,7 @@
     "ax.set_xlabel(\"Number of structures\")\n",
     "ax.set_ylabel(\"Kinase name\")\n",
     "for i, value in enumerate(n_structures_per_kinase):\n",
-    "    ax.text(value, i, str(value), va=\"center\")\n",
-    "# NBVAL_CHECK_OUTPUT"
+    "    ax.text(value, i, str(value), va=\"center\")"
    ]
   },
   {
@@ -1335,9 +1334,7 @@
     "plt.boxplot(D_condensed)\n",
     "plt.xticks([1], [example])\n",
     "plt.ylabel(\"Distance between structures\")\n",
-    "# plt.xlabel(\"EGFR\")\n",
-    "plt.show()\n",
-    "# NBVAL_CHECK_OUTPUT"
+    "plt.show()"
    ]
   },
   {


### PR DESCRIPTION
## Description
T025+26: Apparently, the default figure size increased from 432x288 to 640x480 (in Jupyter Lab and Notebook). 
  - I am dropping the `nbval` check because I think it is enough to be informed if the cell fails instead of if the string `(<Figure size 432x288 with 1 Axes>, <AxesSubplot:>)` changes; both figure sizes are fine :) 
  - FYI, we are not `nbval`-checking plots in other talktorials. I might have missed some cases, but we usually do not.

## Status
- [x] Ready to go