### PR TITLE
CI: Revert Win Py3.9 back to Py3.8; pin `tensorflow`<=2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - os: macos-latest
             python-version: "3.8"
           - os: windows-latest
-            python-version: "3.9"
+            python-version: "3.8"
 
     env:
       PYVER: ${{ matrix.cfg.python-version }}

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -13,7 +13,8 @@ dependencies:
   # Explicitly add numpy because of https://github.com/volkamerlab/teachopencadd/issues/150
   - numpy
   - scikit-learn
-  - tensorflow>=2.0
+  # API changed after v2.6, see https://github.com/volkamerlab/teachopencadd/issues/265
+  - tensorflow<=2.6
   - seaborn
   - matplotlib-venn
   # Remove jsonschema once this issue is fixed: https://github.com/Yelp/bravado/issues/478


### PR DESCRIPTION
## Description
While looking into the `tensorflow` issue reported in https://github.com/volkamerlab/teachopencadd/issues/265, I noticed that we are running the CI for Windows under Py3.9 although we intended to run all platforms by default under Py3.8 (plus an additional test for Py3.9 under Linux).
I introduced this discrepency when I made a CI test run for Win Py3.9 and forgot (?) to revert back to Py3.8: https://github.com/volkamerlab/teachopencadd/pull/254#issuecomment-1191507478 (the exact commit: https://github.com/volkamerlab/teachopencadd/commit/f1596b4171d623145935e64d32c26a8db4560201)

Pin `tensorflow` version matching the API used in T021 and T022 (i.e. 2.6).

## Todos
- [x] Revert CI back to Win Py3.8
- [x] Pin `tensorflow` <=2.6

## Status
- [x] Ready to go