### PR TITLE
Docs: Update TeachOpenCADD citations

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,50 +60,8 @@ Table of contents
 Citation
 --------
 
-If you make use of the TeachOpenCADD material in scientific publications, please cite our respective articles:
-
-- `TeachOpenCADD Jupyter Notebooks: Talktorials T001-T010 <https://jcheminf.biomedcentral.com/articles/10.1186/s13321-019-0351-x>`_
-- `TeachOpenCADD KNIME workflows <https://pubs.acs.org/doi/10.1021/acs.jcim.9b00662>`_
-- `How to use the TeachOpenCADD material for teaching? <https://pubs.acs.org/doi/abs/10.1021/bk-2021-1387.ch010>`_
-
-It will help measure the impact of the TeachOpenCADD platform and future funding!
-
-.. code-block::
-
-   @article{TeachOpenCADD2019,
-      author = {Sydow, Dominique and Morger, Andrea and Driller, Maximilian and Volkamer, Andrea},
-      title = {{TeachOpenCADD: a teaching platform for computer-aided drug design using open source packages and data}},
-      doi = {10.1186/s13321-019-0351-x},
-      url = {https://doi.org/10.1186/s13321-019-0351-x},
-      journal = {J. Cheminform.},
-      volume = {11},
-      number = {1},
-      pages = {29},
-      year = {2019}
-   }
-
-   @article{TeachOpenCADDKNIME2019,
-      author = {Sydow, Dominique and Wichmann, Michele and Rodríguez-Guerra, Jaime and Goldmann, Daria and Landrum, Gregory and Volkamer, Andrea},
-      title = {{TeachOpenCADD-KNIME: A Teaching Platform for Computer-Aided Drug Design Using KNIME Workflows}},
-      doi = {10.1021/acs.jcim.9b00662},
-      url = {https://doi.org/10.1021/acs.jcim.9b00662},
-      journal = {Journal of Chemical Information and Modeling},
-      volume = {59},
-      number = {10},
-      pages = {4083-4086},
-      year = {2019}
-   }
-
-   @inbook{doi:10.1021/bk-2021-1387.ch010,
-      author = {Sydow, Dominique and Rodríguez-Guerra, Jaime and Volkamer, Andrea},
-      title = {Teaching Computer-Aided Drug Design Using TeachOpenCADD},
-      booktitle = {Teaching Programming across the Chemistry Curriculum},
-      chapter = {10},
-      pages = {135-158},
-      doi = {10.1021/bk-2021-1387.ch010},
-      URL = {https://pubs.acs.org/doi/abs/10.1021/bk-2021-1387.ch010},
-   }
-
+If you make use of the TeachOpenCADD material in scientific publications,
+please cite our respective articles as summarized `here <https://github.com/volkamerlab/teachopencadd#citation>`_.
 
 Funding
 -------

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -32,7 +32,7 @@ Install from the conda package
    In this example command, you are setting up your workspace in the current directory ``.``; you can use any other path.
 
 You can always return to your TeachOpenCADD material with ``jupyter lab /path/to/your/teachopencadd/workspace``.
-If you need an introduction to Jupyter notebooks, please check :ref:`here<jupyter_tutorial>` 
+If you need an introduction to Jupyter notebooks, please check out the suggested resources :ref:`here<jupyter_tutorial>`.
 
 Install from the latest development snapshot
 --------------------------------------------


### PR DESCRIPTION
## Description
TeachOpenCADD citations on website are out-of-date. Remove existing text and only link to README citation section, which is up-to-date.

## Todos
- [x] Docs: link to README citation section

## Status
- [x] Ready to go