### PR TITLE
Base branch for CI/env fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "base-ci-env-fix"
   pull_request:
     branches:
       - "master"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,10 @@ jobs:
         run: |
           PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
 
-          # Ignored notebooks
+          # Ignore T019 under Windows, see https://github.com/volkamerlab/teachopencadd/issues/313
           PYTEST_IGNORE_T019="--ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb"
 
-          # Temporarily ignored notebooks
+          # Temporarily ignored notebooks, see https://github.com/volkamerlab/teachopencadd/issues/303
           PYTEST_IGNORE_T008="--ignore=teachopencadd/talktorials/T008_query_pdb/talktorial.ipynb"
 
           if [ "$RUNNER_OS" != "Windows" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - "master"
-      - "maintenance/.+"
+      - "base-ci-env-fix"
   pull_request:
     branches:
       - "master"
-      - "maintenance/.+"
+      - "base-ci-env-fix"
   schedule:
     # Run a cron job once weekly on Monday
     - cron: "0 3 * * 1"
@@ -76,10 +76,11 @@ jobs:
         shell: bash -l {0}
         run: |
           PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
+          PYTEST_IGNORE="--ignore=teachopencadd/talktorials/T021_one_hot_encoding/talktorial.ipynb --ignore=teachopencadd/talktorials/T022_ligand_based_screening_neural_network/talktorial.ipynb"
           if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb
+            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE
           else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ --ignore=teachopencadd/talktorials/T008_md_simulation/talktorial.ipynb --ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ --ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb $PYTEST_IGNORE
           fi
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,20 @@ jobs:
         shell: bash -l {0}
         run: |
           PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
-          PYTEST_IGNORE="--ignore=teachopencadd/talktorials/T021_one_hot_encoding/talktorial.ipynb --ignore=teachopencadd/talktorials/T022_ligand_based_screening_neural_network/talktorial.ipynb"
+
+          # Ignored notebooks
+          PYTEST_IGNORE_T019_Windows="--ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb"
+
+          # Temporarily ignored notebooks
+          PYTEST_IGNORE_T008="--ignore=teachopencadd/talktorials/T008_query_pdb/talktorial.ipynb"
+          PYTEST_IGNORE_T021="--ignore=teachopencadd/talktorials/T021_one_hot_encoding/talktorial.ipynb"
+          PYTEST_IGNORE_T022="--ignore=teachopencadd/talktorials/T022_ligand_based_screening_neural_network/talktorial.ipynb"
+
           if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE
+            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE_T008 $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
+
           else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ --ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb $PYTEST_IGNORE
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T008  $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
           fi
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,16 +81,12 @@ jobs:
 
           # Temporarily ignored notebooks
           PYTEST_IGNORE_T008="--ignore=teachopencadd/talktorials/T008_query_pdb/talktorial.ipynb"
-          PYTEST_IGNORE_T021="--ignore=teachopencadd/talktorials/T021_one_hot_encoding/talktorial.ipynb"
-          PYTEST_IGNORE_T022="--ignore=teachopencadd/talktorials/T022_ligand_based_screening_neural_network/talktorial.ipynb"
 
           if [ "$RUNNER_OS" != "Windows" ]; then
-            #pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE_T008 $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb
+            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE_T008
 
           else
-            #pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T008  $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
-            echo "hello"
+            #pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T008
           fi
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,8 @@ jobs:
           PYTEST_IGNORE_T008="--ignore=teachopencadd/talktorials/T008_query_pdb/talktorial.ipynb"
 
           if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T008
+            # Temporarily ignore T019
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T008 $PYTEST_IGNORE_T019
           else
             pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T008 $PYTEST_IGNORE_T019
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,15 @@ jobs:
           PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
 
           # Ignored notebooks
-          PYTEST_IGNORE_T019_Windows="--ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb"
+          PYTEST_IGNORE_T019="--ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb"
 
           # Temporarily ignored notebooks
           PYTEST_IGNORE_T008="--ignore=teachopencadd/talktorials/T008_query_pdb/talktorial.ipynb"
 
           if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE_T008
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T008
           else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T008
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T008 $PYTEST_IGNORE_T019
           fi
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,12 @@ jobs:
           PYTEST_IGNORE_T022="--ignore=teachopencadd/talktorials/T022_ligand_based_screening_neural_network/talktorial.ipynb"
 
           if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE_T008 $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
+            #pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE_T008 $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
+            pytest $PYTEST_ARGS teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb
 
           else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T008  $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
+            #pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T008  $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
+            echo "hello"
           fi
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,8 @@ jobs:
 
           if [ "$RUNNER_OS" != "Windows" ]; then
             pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE_T008
-
           else
-            #pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T008
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T008
           fi
 
   format:

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -36,7 +36,8 @@ dependencies:
   - mdtraj
   - plip
   - openmm
-  # depends on openff-toolkit->ambertools -> not available on Windows yet!
+  # depends on openff-toolkit -> ambertools -> not available on Windows yet!
+  # we install openmmforcefields in T019 under Linux and MacOS
   # - openmmforcefields
   - pdbfixer
   - tqdm

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -13,8 +13,9 @@ dependencies:
   # New numpy version 1.2.4 too young, e.g. caused
   # https://github.com/volkamerlab/teachopencadd/issues/299
   - numpy<1.24
-  - tensorflow
   - scikit-learn
+  # API changed after v2.6, see https://github.com/volkamerlab/teachopencadd/issues/265
+  - tensorflow<=2.6
   - seaborn
   - matplotlib-venn
   - bravado

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -8,7 +8,7 @@ dependencies:
   - jupyter
   - jupyterlab>=3
   - nglview>=3
-  # https://github.com/volkamerlab/teachopencadd/issues/262
+  # Workaround for nglview, see https://github.com/volkamerlab/teachopencadd/issues/262
   - ipywidgets<8
   # New numpy version 1.2.4 too young, e.g. caused
   # https://github.com/volkamerlab/teachopencadd/issues/299
@@ -62,8 +62,6 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery
   - autodocsumm
-  ## temporary fix for rdkit on MacOS
-  #- fontconfig==2.13.1
   - pip:
       - black-nb
       - nbsphinx-link

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -6,6 +6,8 @@ dependencies:
   - python>=3.8
   - pip
   - jupyterlab>=3
+  # Workaround for jupyterlab, see https://github.com/volkamerlab/teachopencadd/issues/310
+  - jsonschema>=4.3.0
   - nglview>=3
   # Workaround for nglview, see https://github.com/volkamerlab/teachopencadd/issues/262
   - ipywidgets<8

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -63,7 +63,7 @@ dependencies:
   - sphinx-gallery
   - autodocsumm
   ## temporary fix for rdkit on MacOS
-  - fontconfig==2.13.1
+  #- fontconfig==2.13.1
   - pip:
       - black-nb
       - nbsphinx-link

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -16,8 +16,6 @@ dependencies:
   - scikit-learn
   - seaborn
   - matplotlib-venn
-  # Remove jsonschema once this issue is fixed: https://github.com/Yelp/bravado/issues/478
-  - jsonschema<4.0.0
   - bravado
   - requests
   - requests-cache

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -38,8 +38,7 @@ dependencies:
   - mdtraj
   - plip
   - openmm
-  # depends on openff-toolkit -> ambertools -> not available on Windows yet!
-  # we install openmmforcefields in T019 under Linux and MacOS
+  # Dependency not included, see https://github.com/volkamerlab/teachopencadd/issues/313
   # - openmmforcefields
   - pdbfixer
   - tqdm

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -5,7 +5,6 @@ channels:
 dependencies:
   - python>=3.8
   - pip
-  - jupyter
   - jupyterlab>=3
   - nglview>=3
   # Workaround for nglview, see https://github.com/volkamerlab/teachopencadd/issues/262

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -46,8 +46,7 @@ dependencies:
   - lxml
   - kissim
   ## CI tests
-  # Workaround for https://github.com/computationalmodelling/nbval/issues/153
-  - pytest 5.*
+  - pytest
   - pytest-xdist
   - pytest-cov
   - nbval

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -10,7 +10,8 @@ dependencies:
   - nglview>=3
   # https://github.com/volkamerlab/teachopencadd/issues/262
   - ipywidgets<8
-  # New numpy version too young
+  # New numpy version 1.2.4 too young, e.g. caused
+  # https://github.com/volkamerlab/teachopencadd/issues/299
   - numpy<1.24
   - tensorflow
   - scikit-learn

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -1,4 +1,4 @@
-﻿name: teachopencadd
+name: teachopencadd
 channels:
   - conda-forge
   - defaults
@@ -10,11 +10,10 @@ dependencies:
   - nglview>=3
   # https://github.com/volkamerlab/teachopencadd/issues/262
   - ipywidgets<8
-  # Explicitly add numpy because of https://github.com/volkamerlab/teachopencadd/issues/150
-  - numpy
+  # New numpy version too young
+  - numpy<1.24
+  - tensorflow
   - scikit-learn
-  # API changed after v2.6, see https://github.com/volkamerlab/teachopencadd/issues/265
-  - tensorflow<=2.6
   - seaborn
   - matplotlib-venn
   # Remove jsonschema once this issue is fixed: https://github.com/Yelp/bravado/issues/478
@@ -44,6 +43,8 @@ dependencies:
   - tqdm
   - lxml
   - kissim
+  # API changed after v2.6, see https://github.com/volkamerlab/teachopencadd/issues/265
+  #- tensorflow
   ## CI tests
   # Workaround for https://github.com/computationalmodelling/nbval/issues/153
   - pytest 5.*

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -43,8 +43,6 @@ dependencies:
   - tqdm
   - lxml
   - kissim
-  # API changed after v2.6, see https://github.com/volkamerlab/teachopencadd/issues/265
-  #- tensorflow
   ## CI tests
   # Workaround for https://github.com/computationalmodelling/nbval/issues/153
   - pytest 5.*

--- a/teachopencadd/talktorials/T008_query_pdb/README.md
+++ b/teachopencadd/talktorials/T008_query_pdb/README.md
@@ -1,3 +1,12 @@
+<div class="alert alert-block alert-danger">
+
+<b>TeachOpenCADD note</b>: This notebook uses the Ligand Expo website (http://ligand-expo.rcsb.org/), which will be offline in January 2023. During that time, T008 will not work in its entirety. Please check the following issue to track when this notebook will be available again: https://github.com/volkamerlab/teachopencadd/issues/303
+    
+<b>Ligand Expo website note</b>: "Ligand Expo will be down from January 1-31, 2023. Requests to this service will return a 410 http error code (“Gone”) and a message to contact RCSB PDB."
+
+</div>
+
+
 # T008 · Protein data acquisition: Protein Data Bank (PDB) 
 
 **Note:** This talktorial is a part of TeachOpenCADD, a platform that aims to teach domain-specific skills and to provide pipeline templates as starting points for research projects.

--- a/teachopencadd/talktorials/T008_query_pdb/talktorial.ipynb
+++ b/teachopencadd/talktorials/T008_query_pdb/talktorial.ipynb
@@ -4,6 +4,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-block alert-danger\">\n",
+    "\n",
+    "<b>TeachOpenCADD note</b>: This notebook uses the Ligand Expo website (http://ligand-expo.rcsb.org/), which will be offline in January 2023. During that time, T008 will not work in its entirety. Please check the following issue to track when this notebook will be available again: https://github.com/volkamerlab/teachopencadd/issues/303\n",
+    "    \n",
+    "<b>Ligand Expo website note</b>: \"Ligand Expo will be down from January 1-31, 2023. Requests to this service will return a 410 http error code (“Gone”) and a message to contact RCSB PDB.\"\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# T008 · Protein data acquisition: Protein Data Bank (PDB) \n",
     "\n",
     "**Note:** This talktorial is a part of TeachOpenCADD, a platform that aims to teach domain-specific skills and to provide pipeline templates as starting points for research projects.\n",

--- a/teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb
+++ b/teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb
@@ -353,7 +353,11 @@
    "source": [
     "import sys\n",
     "if not on_colab and sys.platform.startswith((\"linux\", \"darwin\")):\n",
-    "    !conda install -q -y -c conda-forge openmmforcefields"
+    "    !mamba install -q -y -c conda-forge openmmforcefields\n",
+    "    # Notes:\n",
+    "    # - If you do not have mamba installed, install it or use conda instead\n",
+    "    # - Under MacOS with an M1 chip you may need to use\n",
+    "    #   CONDA_SUBDIR=osx-64 in front of the above command"
    ]
   },
   {
@@ -394,9 +398,9 @@
     "from rdkit.Chem import AllChem\n",
     "import mdtraj as md\n",
     "import pdbfixer\n",
-    "import simtk.openmm as mm\n",
-    "import simtk.openmm.app as app\n",
-    "from simtk.openmm import unit\n",
+    "import openmm as mm\n",
+    "import openmm.app as app\n",
+    "from openmm import unit\n",
     "from openff.toolkit.topology import Molecule, Topology\n",
     "from openmmforcefields.generators import GAFFTemplateGenerator"
    ]
@@ -718,10 +722,9 @@
     "    mol_topology = off_mol_topology.to_openmm()\n",
     "    mol_positions = off_mol.conformers[0]\n",
     "\n",
-    "    # convert units from Ångström to Nanometers\n",
-    "    for atom in mol_positions:\n",
-    "        coords = atom / atom.unit\n",
-    "        atom = (coords / 10.0) * unit.nanometers  # since openmm works in nm\n",
+    "    # convert units from Ångström to nanometers\n",
+    "    # since OpenMM works in nm\n",
+    "    mol_positions = mol_positions.to(\"nanometers\")\n",
     "\n",
     "    # combine topology and positions in modeller object\n",
     "    omm_mol = app.Modeller(mol_topology, mol_positions)\n",

--- a/teachopencadd/talktorials/T022_ligand_based_screening_neural_network/talktorial.ipynb
+++ b/teachopencadd/talktorials/T022_ligand_based_screening_neural_network/talktorial.ipynb
@@ -375,6 +375,7 @@
     "import numpy as np\n",
     "from rdkit import Chem\n",
     "from rdkit.Chem import MACCSkeys, Draw\n",
+    "from rdkit.Chem.AllChem import GetMorganFingerprintAsBitVect\n",
     "from sklearn.model_selection import train_test_split\n",
     "import matplotlib.pyplot as plt\n",
     "from sklearn import metrics\n",


### PR DESCRIPTION
## Description
Current `teachopencadd` has a couple of dependency conflicts and deps-unrelated `pytest` fails.
This base branch shall be used to get a fully passing CI, while fixing all the different bits and pieces in smaller PRs.

## Todos
- [x] https://github.com/volkamerlab/teachopencadd/pull/294 -- pin `numpy<1.24` and unpin `tensorflow`; do not test T021/22 and deal with it later (see below)
  - [x] #299 
- [x] https://github.com/volkamerlab/teachopencadd/pull/297
  - [x] #152 
- [x] https://github.com/volkamerlab/teachopencadd/pull/304
  - [x] #300 
- [x] https://github.com/volkamerlab/teachopencadd/pull/305
  - #303 --- do not close before at least Feb
- [x] https://github.com/volkamerlab/teachopencadd/pull/306
  - [x] #298
- [x] https://github.com/volkamerlab/teachopencadd/issues/302
- [x] https://github.com/volkamerlab/teachopencadd/pull/309
  - [x] https://github.com/volkamerlab/teachopencadd/issues/289
  - [x] https://github.com/volkamerlab/teachopencadd/issues/265
- [x] #310
  - Fixed in https://github.com/volkamerlab/teachopencadd/pull/296/commits/eccb30addd07f6a6ec30acf16c25ba108cbc62a1
- [x] Unpin `fontconfig` because https://github.com/conda-forge/fontconfig-feedstock/issues/54 seems fixed?
  - Seems fine, all tests are passing as before after https://github.com/volkamerlab/teachopencadd/pull/296/commits/6d8e5015fdc5145f52bb1180de27b5f28cf86e2a
- [ ] At the end: Remove `base-ci-env-fix` branch from CI.yml

## Notes: After this PR's merge
...continue with TODOs in #312

## Status
- [x] Ready to go