### PR TITLE
T008: Remove from CI in Jan 2023

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,19 @@ jobs:
         shell: bash -l {0}
         run: |
           PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
-          PYTEST_IGNORE="--ignore=teachopencadd/talktorials/T021_one_hot_encoding/talktorial.ipynb --ignore=teachopencadd/talktorials/T022_ligand_based_screening_neural_network/talktorial.ipynb"
+
+          # Ignored notebooks
+          PYTEST_IGNORE_T019_Windows="--ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb"
+
+          # Temporarily ignored notebooks
+          PYTEST_IGNORE_T008="--ignore=teachopencadd/talktorials/T008_query_pdb/talktorial.ipynb"
+          PYTEST_IGNORE_T021="--ignore=teachopencadd/talktorials/T021_one_hot_encoding/talktorial.ipynb"
+          PYTEST_IGNORE_T022="--ignore=teachopencadd/talktorials/T022_ligand_based_screening_neural_network/talktorial.ipynb"
+
           if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE
+            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE $PYTEST_IGNORE_T008
           else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ --ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb $PYTEST_IGNORE
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T008 $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
           fi
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,10 @@ jobs:
           PYTEST_IGNORE_T022="--ignore=teachopencadd/talktorials/T022_ligand_based_screening_neural_network/talktorial.ipynb"
 
           if [ "$RUNNER_OS" != "Windows" ]; then
-            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE $PYTEST_IGNORE_T008
+            pytest $PYTEST_ARGS teachopencadd/talktorials/T*/talktorial.ipynb $PYTEST_IGNORE_T008 $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
+
           else
-            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T008 $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
+            pytest $PYTEST_ARGS teachopencadd/talktorials/ $PYTEST_IGNORE_T019_Windows $PYTEST_IGNORE_T008  $PYTEST_IGNORE_T021 $PYTEST_IGNORE_T022
           fi
 
   format:

--- a/teachopencadd/talktorials/T008_query_pdb/README.md
+++ b/teachopencadd/talktorials/T008_query_pdb/README.md
@@ -1,3 +1,12 @@
+<div class="alert alert-block alert-danger">
+
+<b>TeachOpenCADD note</b>: This notebook uses the Ligand Expo website (http://ligand-expo.rcsb.org/), which will be offline in January 2023. During that time, T008 will not work in its entirety. Please check the following issue to track when this notebook will be available again: https://github.com/volkamerlab/teachopencadd/issues/303
+    
+<b>Ligand Expo website note</b>: "Ligand Expo will be down from January 1-31, 2023. Requests to this service will return a 410 http error code (“Gone”) and a message to contact RCSB PDB."
+
+</div>
+
+
 # T008 · Protein data acquisition: Protein Data Bank (PDB) 
 
 **Note:** This talktorial is a part of TeachOpenCADD, a platform that aims to teach domain-specific skills and to provide pipeline templates as starting points for research projects.

--- a/teachopencadd/talktorials/T008_query_pdb/talktorial.ipynb
+++ b/teachopencadd/talktorials/T008_query_pdb/talktorial.ipynb
@@ -4,6 +4,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-block alert-danger\">\n",
+    "\n",
+    "<b>TeachOpenCADD note</b>: This notebook uses the Ligand Expo website (http://ligand-expo.rcsb.org/), which will be offline in January 2023. During that time, T008 will not work in its entirety. Please check the following issue to track when this notebook will be available again: https://github.com/volkamerlab/teachopencadd/issues/303\n",
+    "    \n",
+    "<b>Ligand Expo website note</b>: \"Ligand Expo will be down from January 1-31, 2023. Requests to this service will return a 410 http error code (“Gone”) and a message to contact RCSB PDB.\"\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# T008 · Protein data acquisition: Protein Data Bank (PDB) \n",
     "\n",
     "**Note:** This talktorial is a part of TeachOpenCADD, a platform that aims to teach domain-specific skills and to provide pipeline templates as starting points for research projects.\n",


### PR DESCRIPTION
## Description
T008 won't work in Jan 2023 because of https://github.com/volkamerlab/teachopencadd/issues/303

## Todos
- [x] Add note to talktorial header
- [x] Regenerate README
- [x] Remove T008 from CI in Jan 2023

## Status
- [x] Ready to go