### PR TITLE
Update TeachOpenCADD website (docs) and repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ If you prefer to work in the context of a graphical interface, talktorials T001-
 
 ## About TeachOpenCADD
 
+Coming soon.
+<!---
 - [Contact](https://projects.volkamerlab.org/teachopencadd/contact.html)
 - [Acknowledgments](https://projects.volkamerlab.org/teachopencadd/acknowledgments.html)
 - [Citation](https://projects.volkamerlab.org/teachopencadd/citation.html)
 - [License](https://projects.volkamerlab.org/teachopencadd/license.html)
 - [Funding](https://projects.volkamerlab.org/teachopencadd/funding.html)
-
+--->
 
 
 ## External resources

--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ A teaching platform for computer-aided drug design (CADD) using open source pack
 ![GitHub closed pr](https://img.shields.io/github/issues-pr-closed-raw/volkamerlab/teachopencadd) ![GitHub open pr](https://img.shields.io/github/issues-pr-raw/volkamerlab/teachopencadd) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/volkamerlab/teachopencadd) ![GitHub open issues](https://img.shields.io/github/issues/volkamerlab/teachopencadd)
 
 > If you use TeachOpenCADD in a publication,
-> please [cite](https://projects.volkamerlab.org/teachopencadd/citation.html) us!
+> please [cite](https://projects.volkamerlab.org/teachopencadd) us!
 > If you use TeachOpenCADD in class, please include a link back to our repository.
 <!-- markdown-link-check-disable-next-line -->
 > In any case, please [star](https://docs.github.com/en/get-started/exploring-projects-on-github/saving-repositories-with-stars)
 > (and tell your students to star) those repositories you consider useful for your learning/teaching activities.
+
+<!---https://projects.volkamerlab.org/teachopencadd/citation.html--->
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # TeachOpenCADD
+
 A teaching platform for computer-aided drug design (CADD) using open source packages and data.
 
 ![TOC](https://img.shields.io/badge/Project-TeachOpenCADD-pink)
@@ -12,18 +13,16 @@ A teaching platform for computer-aided drug design (CADD) using open source pack
 [![GH Actions Docs](https://github.com/volkamerlab/teachopencadd/workflows/Docs/badge.svg)](https://projects.volkamerlab.org/teachopencadd/)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/teachopencadd/badges/downloads.svg)](https://anaconda.org/conda-forge/teachopencadd)
 
-Open source programming packages for cheminformatics and structural bioinformatics are powerful tools to build modular, reproducible, and reusable pipelines for computer-aided drug design (CADD). While documentation for such tools is available, only few freely accessible examples teach underlying concepts focused on CADD applications, addressing especially users new to the field.
-
-TeachOpenCADD is a teaching platform developed by students for students, which provides teaching material for central CADD topics. Since we cover both the theoretical as well as practical aspect of these topics, the platform addresses students and researchers with a biological/chemical as well as a computational background.
-
-Each topic is covered in an interactive Jupyter Notebook, using open source packages such as the Python packages `rdkit`, `pypdb`, `biopandas`, `nglview`, and `mdanalysis` (find the full list [here](https://github.com/volkamerlab/teachopencadd#external-resources)). Topics are continuously expanded and open for contributions from the community. Beyond their teaching purpose, the TeachOpenCADD material can serve as starting point for users’ project-directed modifications and extensions.
+![GitHub closed pr](https://img.shields.io/github/issues-pr-closed-raw/volkamerlab/teachopencadd) ![GitHub open pr](https://img.shields.io/github/issues-pr-raw/volkamerlab/teachopencadd) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/volkamerlab/teachopencadd) ![GitHub open issues](https://img.shields.io/github/issues/volkamerlab/teachopencadd)
 
 > If you use TeachOpenCADD in a publication,
-> please [cite](https://github.com/volkamerlab/TeachOpenCADD/blob/master/README.md#citation) us!
+> please [cite](https://projects.volkamerlab.org/teachopencadd/citation.html) us!
 > If you use TeachOpenCADD in class, please include a link back to our repository.
 <!-- markdown-link-check-disable-next-line -->
 > In any case, please [star](https://docs.github.com/en/get-started/exploring-projects-on-github/saving-repositories-with-stars)
 > (and tell your students to star) those repositories you consider useful for your learning/teaching activities.
+
+## Description
 
 <p align="center">
   <img src="docs/_static/images/TeachOpenCADD_topics.png" alt="TeachOpenCADD topics" width="800"/>
@@ -34,6 +33,12 @@ Each topic is covered in an interactive Jupyter Notebook, using open source pack
   (D. Sydow <i>et al.</i>, J. Cheminformatics, 2019)</a>.
   </font>
 </p>
+
+Open source programming packages for cheminformatics and structural bioinformatics are powerful tools to build modular, reproducible, and reusable pipelines for computer-aided drug design (CADD). While documentation for such tools is available, only few freely accessible examples teach underlying concepts focused on CADD applications, addressing especially users new to the field.
+
+TeachOpenCADD is a teaching platform developed by students for students, which provides teaching material for central CADD topics. Since we cover both the theoretical as well as practical aspect of these topics, the platform addresses students and researchers with a biological/chemical as well as a computational background.
+
+Each topic is covered in an interactive Jupyter Notebook, using open source packages such as the Python packages `rdkit`, `pypdb`, `biopandas`, `nglview`, and `mdanalysis` (find the full list [here](https://projects.volkamerlab.org/teachopencadd/external_dependencies.html)). Topics are continuously expanded and open for contributions from the community. Beyond their teaching purpose, the TeachOpenCADD material can serve as starting point for users’ project-directed modifications and extensions.
 
 ## Get started
 
@@ -57,212 +62,20 @@ If you'd like to execute the provided notebooks, we offer two possibilities:
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3626897.svg)](https://doi.org/10.5281/zenodo.3626897)
 [![KNIME Hub](https://img.shields.io/badge/KNIME%20Hub-TeachOpenCADD--KNIME-yellow.svg)](https://hub.knime.com/volkamerlab/spaces/Public/latest/TeachOpenCADD/TeachOpenCADD)
 
-If you prefer to work in the context of a graphical interface, talktorials T001-T008 are also available as [KNIME workflows](https://hub.knime.com/volkamerlab/space/TeachOpenCADD/TeachOpenCADD). Questions regarding this version should be addressed using the "Discussion section" available at [this post](https://forum.knime.com/t/teachopencadd-knime/17174). You might need to create a KNIME account.
+If you prefer to work in the context of a graphical interface, talktorials T001-T008 are also available as [KNIME workflows](https://hub.knime.com/volkamerlab/space/TeachOpenCADD/TeachOpenCADD). Questions regarding this version should be addressed using the "Discussion section" available at [this post](https://forum.knime.com/t/teachopencadd-knime/17174). You need to create a KNIME account to use the forum.
+
+## About TeachOpenCADD
+
+- [Contact](https://projects.volkamerlab.org/teachopencadd/contact.html)
+- [Acknowledgments](https://projects.volkamerlab.org/teachopencadd/acknowledgments.html)
+- [Citation](https://projects.volkamerlab.org/teachopencadd/citation.html)
+- [License](https://projects.volkamerlab.org/teachopencadd/license.html)
+- [Funding](https://projects.volkamerlab.org/teachopencadd/funding.html)
+
+
 
 ## External resources
 
-### Python programming introduction
-
-The TeachOpenCADD platform is not a Python programming course from scratch but teaches how to solve tasks in cheminformatics and structural bioinformatics programmatically.
-If you wish to get started first with a Python programming introduction before diving into the TeachOpenCADD material, here are a few great resources to do so:
-
-- [AI in Medicine course](https://github.com/volkamerlab/ai_in_medicine) by the [Volkamer Lab](https://volkamerlab.org/) and [Ritter Lab](https://psychiatrie-psychotherapie.charite.de/metas/person/person/address_detail/ritter-7/) at the Charité: Introduction to Python basics, Jupyter Notebook, and important data science packages such as Pandas, Matplotlib and Scikit-learn
-- [Python for Chemists course](https://github.com/GDChCICTeam/python-for-chemists) by the [GDCh/CIC](https://en.gdch.de/network-structures/divisions/computers-in-chemistry-cic.html) team: Crash-course introduction to Python for natural scientists
-- [MolSSI Education Resources](http://education.molssi.org/resources.html) by [The Molecular Sciences Software Institute](https://molssi.org/): Collection of tutorials on Python programming basics and data analysis but also more advanced material on software development and computational molecular science
-- [Core lessons](https://software-carpentry.org/lessons/) by the [Software Carpentry](https://software-carpentry.org/): Introduction to Python, Git, command line interfaces and more
-
-### Cheminformatics resources
-
-The following resources are collections of interesting cheminformatics-related training material, blogs, and books.
-
-- [Curated list of resources from the RDKit UGM 2020](https://github.com/rdkit/UGM_2020/blob/master/info/curated_list_of_resources.md)
-- [A Highly Opinionated List of Open Source Cheminformatics Resources](https://github.com/PatWalters/resources/blob/main/cheminformatics_resources.md) by Pat Walters
-- [Awesome Cheminformatics](https://github.com/hsiaoyi0504/awesome-cheminformatics#resources) by Yi Hsiao
-
-### Structural bioinformatics resources
-
-- [Education & Tutorials of the Bonvin Lab](https://www.bonvinlab.org/education/molmod_online/)
-
-## Contact
-
-![GitHub closed pr](https://img.shields.io/github/issues-pr-closed-raw/volkamerlab/teachopencadd) ![GitHub open pr](https://img.shields.io/github/issues-pr-raw/volkamerlab/teachopencadd) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/volkamerlab/teachopencadd) ![GitHub open issues](https://img.shields.io/github/issues/volkamerlab/teachopencadd)
-
-Please contact us if you have questions or suggestions!
-
-- If you have questions regarding our Jupyter Notebooks, please [open an issue](https://github.com/volkamerlab/teachopencadd/issues) on our GitHub repository.
-- If you have ideas for new topics, please fill out our questionnaire: [contribute.volkamerlab.org](http://contribute.volkamerlab.org)
-
-We are looking forward to hearing from you!
-
-## License
-
-This work is licensed under the Attribution 4.0 International (CC BY 4.0).
-To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/.
-
-## Citation
-
-If you make use of the TeachOpenCADD material in scientific publications, please cite our respective articles. It will help measure the impact of the TeachOpenCADD platform and future funding, thank you!
-
-### TeachOpenCADD Jupyter notebooks
-
-TeachOpenCADD Jupyter notebooks' main citation: Talktorials T001-T022 ([paper](https://academic.oup.com/nar/advance-article/doi/10.1093/nar/gkac267/6582172))
-
-```
-@article{TeachOpenCADD2022,
-    author = {Sydow, Dominique and Rodríguez-Guerra, Jaime and Kimber, Talia B and Schaller, David and Taylor, Corey J and Chen, Yonghui and Leja, Mareike and Misra, Sakshi and Wichmann, Michele and Ariamajd, Armin and Volkamer, Andrea},
-    title = {TeachOpenCADD 2022: open source and FAIR Python pipelines to assist in structural bioinformatics and cheminformatics research},
-    journal = {Nucleic Acids Research},
-    year = {2022},
-    doi = {10.1093/nar/gkac267},
-}
-```
-
-TeachOpenCADD Jupyter notebooks' original citation: Talktorials T001-T010 ([paper](https://jcheminf.biomedcentral.com/articles/10.1186/s13321-019-0351-x))
-
-```
-@article{TeachOpenCADD2019,
-    author = {Sydow, Dominique and Morger, Andrea and Driller, Maximilian and Volkamer, Andrea},
-    title = {{TeachOpenCADD: a teaching platform for computer-aided drug design using open source packages and data}},
-    journal = {Journal of Cheminformatics},
-    year = {2019},
-    volume = {11},
-    number = {1},
-    pages = {29},
-    doi = {10.1186/s13321-019-0351-x},
-}
-```
-
-<!-- markdown-link-check-disable-next-line -->
-TeachOpenCADD Jupyter notebooks on kinase similarities: Talktorials T023-T028 ([paper](https://doi.org/10.33011/livecoms.3.1.1599))
-
-```
-@article{TeachOpenCADDKinaseEdition,
-    author = {Kimber, Talia B and Sydow, Dominique and Volkamer, Andrea},
-    title = {{Kinase similarity assessment pipeline for off-target prediction [v1.0]}},
-    journal = {Living Journal of Computational Molecular Science},
-    year = {2022},
-    doi = {10.1186/s13321-019-0351-x},
-}
-```
-
-### TeachOpenCADD-KNIME
-
-<!-- markdown-link-check-disable-next-line -->
-TeachOpenCADD KNIME workflows ([paper](https://pubs.acs.org/doi/10.1021/acs.jcim.9b00662))
-
-```
-@article{TeachOpenCADDKNIME2019,
-    author = {Sydow, Dominique and Wichmann, Michele and Rodríguez-Guerra, Jaime and Goldmann, Daria and Landrum, Gregory and Volkamer, Andrea},
-    title = {{TeachOpenCADD-KNIME: A Teaching Platform for Computer-Aided Drug Design Using KNIME Workflows}},
-    journal = {Journal of Chemical Information and Modeling},
-    year = {2019},
-    volume = {59},
-    number = {10},
-    pages = {4083-4086},
-    doi = {10.1021/acs.jcim.9b00662},
-}
-```
-
-### Teaching
-<!-- markdown-link-check-disable-next-line -->
-How to use the TeachOpenCADD material for teaching ([chapter](https://pubs.acs.org/doi/abs/10.1021/bk-2021-1387.ch010))
-
-```
-@inbook{doi:10.1021/bk-2021-1387.ch010,
-    author = {Sydow, Dominique and Rodríguez-Guerra, Jaime and Volkamer, Andrea},
-    title = {Teaching Computer-Aided Drug Design Using TeachOpenCADD},
-    booktitle = {Teaching Programming across the Chemistry Curriculum},
-    chapter = {10},
-    pages = {135-158},
-    doi = {10.1021/bk-2021-1387.ch010},
-}
-```
-
-## Acknowledgments
-
-### External resources
-
-#### Python packages
-
-- Cheminformatics and structural bioinformatics:
-  [`rdkit`](http://rdkit.org/),
-  [`openbabel`](https://openbabel.org/),
-  [`mdanalysis`](https://www.mdanalysis.org/),
-  [`biopython`](https://biopython.org/),
-  [`biopandas`](http://rasbt.github.io/biopandas/),
-  [`opencadd`](https://opencadd.readthedocs.io/en/latest/),
-  [`plip`](https://github.com/pharmai/plip),
-  [`openff`](https://github.com/openforcefield/openff-toolkit),
-  [`openff-toolkit`](https://github.com/openforcefield/openff-toolkit),
-  [`openmmforcefields`](https://github.com/openmm/openmmforcefields),
-  [`pdbfixer`](https://github.com/openmm/pdbfixer),
-  [`mdanalysis`](https://www.mdanalysis.org/),
-  [`biotite`](https://www.biotite-python.org/),
-  [`smina`](https://sourceforge.net/p/smina/discussion/)
-- Data science (PyData stack):
-  [`numpy`](https://numpy.org/),
-  [`pandas`](https://pandas.pydata.org/),
-  [`scikit-learn`](https://scikit-learn.org/),
-  [`keras`](https://keras.io/),
-  [`jupyter`](https://jupyter.org/),
-  [`ipywidgets`](https://ipywidgets.readthedocs.io)
-- Data visualization:
-  [`matplotlib`](https://matplotlib.org/), 
-  [`mpl_toolkits`](https://matplotlib.org/stable/api/toolkits/mplot3d.html),
-  [`matplotlib_venn`](https://github.com/konstantint/matplotlib-venn),
-  [`seaborn`](https://seaborn.pydata.org/),
-  [`nglview`](http://nglviewer.org/nglview/latest/)
-- Web services clients:
-  [`pypdb`](https://github.com/williamgilpin/pypdb),
-  [`chembl_webresource_client`](https://github.com/chembl/chembl_webresource_client),
-  [`requests`](https://requests.readthedocs.io/en/latest/),
-  [`bravado`](https://bravado.readthedocs.io/en/stable/),
-  [`beautifulsoup4`](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)
-- Utilities:
-  [`tqdm`](https://tqdm.github.io/),
-  [`requests_cache`](https://requests-cache.readthedocs.io),
-  [`redo`](https://github.com/mozilla-releng/redo),
-  [`google-colab`](https://pypi.org/project/google-colab/),
-  [`condacolab`](https://pypi.org/project/condacolab/)
-- Continuous integration:
-  [`pytest`](https://docs.pytest.org),
-  [`nbval`](https://nbval.readthedocs.io)
-- Documentation:
-  [`sphinx`](https://www.sphinx-doc.org),
-  [`nbsphinx`](https://nbsphinx.readthedocs.io)
-- Code style:
-  [`black-nb`](https://github.com/tomcatling/black-nb)
-
-#### Databases and webservers
-
-- [ChEMBL](https://www.ebi.ac.uk/chembl/)
-- [RCSB PDB](https://www.rcsb.org/)
-- [KLIFS](https://klifs.net/)
-- [PubMed](https://pubchem.ncbi.nlm.nih.gov/)
-- [ProteinsPlus](https://proteins.plus/)
-
-If we are using your resource and forgot to add it here, please contact us so that we can rectify this, thank you!
-
-### Funding
-
-Volkamer Lab's projects are supported by several public funding sources
-(for more info see our [webpage](https://volkamerlab.org/)).
-
-### Contributors
-
-TeachOpenCADD has been initiated by the members of [Volkamer Lab](https://volkamerlab.org/),
-Charité - Universitätsmedizin Berlin, with special thanks to
-[dominiquesydow](https://github.com/dominiquesydow/),
-[jaimergp](https://github.com/jaimergp/) and
-[AndreaVolkamer](https://github.com/andreavolkamer).
-The platform has been filled with life by our students from the CADD courses taught in the
-bioinformatics program at Freie Universität Berlin.
-
-Many thanks to everyone who has contributed to TeachOpenCADD by working on talktorials
-(check out the talktorial READMEs for author information -
-[example](https://github.com/volkamerlab/teachopencadd/tree/master/teachopencadd/talktorials/T001_query_chembl))
-and/or by helping in any other way (see [GitHub contributors](https://github.com/volkamerlab/teachopencadd/graphs/contributors)).
-
-You are welcome to contribute to the project either by requesting new topics,
-proposing ideas or getting involved in the development!
-Check out our [contributor guide](https://projects.volkamerlab.org/teachopencadd/contribute.html#contribute) for more information!
+Please refer to our TeachOpenCADD website to find a list of external resources:
+- [External packages and webservices](https://projects.volkamerlab.org/teachopencadd/external_dependencies.html) that are used in the TeachOpenCADD material
+- [Further reading material](https://projects.volkamerlab.org/teachopencadd/external_tutorials_collections.html) on Python programming, cheminformatics, structural bioinformatics, and more.

--- a/docs/acknowledgments.rst
+++ b/docs/acknowledgments.rst
@@ -1,0 +1,15 @@
+Acknowledgments
+===============
+
+TeachOpenCADD has been initiated by the members of `Volkamer Lab <https://volkamerlab.org/>`_,
+Charité - Universitätsmedizin Berlin, with special thanks to
+`@dominiquesydow <https://github.com/dominiquesydow/>`_,
+`@jaimergp <https://github.com/jaimergp/>`_ and
+`@AndreaVolkamer <https://github.com/andreavolkamer>`_.
+The platform has been filled with life by our students from the CADD courses taught in the
+bioinformatics program at Freie Universität Berlin.
+
+Many thanks to everyone who has contributed and is contributing to TeachOpenCADD
+by working on talktorials (check out the talktorial READMEs for author information)
+and/or by helping in any other way
+(see `GitHub contributors <https://github.com/volkamerlab/teachopencadd/graphs/contributors>`_).

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -1,0 +1,70 @@
+Citation
+========
+
+If you make use of the TeachOpenCADD material in scientific publications, please cite our respective articles. It will help measure the impact of the TeachOpenCADD platform and future funding, thank you!
+
+TeachOpenCADD Jupyter notebooks
+-------------------------------
+
+TeachOpenCADD Jupyter notebooks' main citation for `talktorials T001-T022 (paper) <https://academic.oup.com/nar/advance-article/doi/10.1093/nar/gkac267/6582172>`_::
+
+    @article{TeachOpenCADD2022,
+        author = {Sydow, Dominique and Rodríguez-Guerra, Jaime and Kimber, Talia B and Schaller, David and Taylor, Corey J and Chen, Yonghui and Leja, Mareike and Misra, Sakshi and Wichmann, Michele and Ariamajd, Armin and Volkamer, Andrea},
+        title = {TeachOpenCADD 2022: open source and FAIR Python pipelines to assist in structural bioinformatics and cheminformatics research},
+        journal = {Nucleic Acids Research},
+        year = {2022},
+        doi = {10.1093/nar/gkac267},
+    }
+
+TeachOpenCADD Jupyter notebooks' original citation for `talktorials T001-T010 (paper) <https://jcheminf.biomedcentral.com/articles/10.1186/s13321-019-0351-x>`_::
+
+    @article{TeachOpenCADD2019,
+        author = {Sydow, Dominique and Morger, Andrea and Driller, Maximilian and Volkamer, Andrea},
+        title = {{TeachOpenCADD: a teaching platform for computer-aided drug design using open source packages and data}},
+        journal = {Journal of Cheminformatics},
+        year = {2019},
+        volume = {11},
+        number = {1},
+        pages = {29},
+        doi = {10.1186/s13321-019-0351-x},
+    }
+
+TeachOpenCADD Jupyter notebooks on kinase similarities spanning `talktorials T023-T028 (paper) <https://doi.org/10.33011/livecoms.3.1.1599>`_::
+
+    @article{TeachOpenCADDKinaseEdition,
+        author = {Kimber, Talia B and Sydow, Dominique and Volkamer, Andrea},
+        title = {{Kinase similarity assessment pipeline for off-target prediction [v1.0]}},
+        journal = {Living Journal of Computational Molecular Science},
+        year = {2022},
+        doi = {10.1186/s13321-019-0351-x},
+    }
+
+TeachOpenCADD-KNIME
+-------------------
+
+TeachOpenCADD `KNIME workflows (paper) <https://pubs.acs.org/doi/10.1021/acs.jcim.9b00662>`_::
+
+    @article{TeachOpenCADDKNIME2019,
+        author = {Sydow, Dominique and Wichmann, Michele and Rodríguez-Guerra, Jaime and Goldmann, Daria and Landrum, Gregory and Volkamer, Andrea},
+        title = {{TeachOpenCADD-KNIME: A Teaching Platform for Computer-Aided Drug Design Using KNIME Workflows}},
+        journal = {Journal of Chemical Information and Modeling},
+        year = {2019},
+        volume = {59},
+        number = {10},
+        pages = {4083-4086},
+        doi = {10.1021/acs.jcim.9b00662},
+    }
+
+Teaching
+--------
+
+How to use the TeachOpenCADD material for `teaching (book chapter) <https://pubs.acs.org/doi/abs/10.1021/bk-2021-1387.ch010>`_::
+
+    @inbook{doi:10.1021/bk-2021-1387.ch010,
+        author = {Sydow, Dominique and Rodríguez-Guerra, Jaime and Volkamer, Andrea},
+        title = {Teaching Computer-Aided Drug Design Using TeachOpenCADD},
+        booktitle = {Teaching Programming across the Chemistry Curriculum},
+        chapter = {10},
+        pages = {135-158},
+        doi = {10.1021/bk-2021-1387.ch010},
+    }

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -13,6 +13,9 @@ TeachOpenCADD Jupyter notebooks' main citation for `talktorials T001-T022 (paper
         title = {TeachOpenCADD 2022: open source and FAIR Python pipelines to assist in structural bioinformatics and cheminformatics research},
         journal = {Nucleic Acids Research},
         year = {2022},
+        volume = {50},
+        number = {W1},
+        pages = {W753–W760},
         doi = {10.1093/nar/gkac267},
     }
 
@@ -36,6 +39,9 @@ TeachOpenCADD Jupyter notebooks on kinase similarities spanning `talktorials T02
         title = {{Kinase similarity assessment pipeline for off-target prediction [v1.0]}},
         journal = {Living Journal of Computational Molecular Science},
         year = {2022},
+        volume = {3},
+        number = {1},
+        pages = {1599},
         doi = {10.1186/s13321-019-0351-x},
     }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,9 @@ html_theme_options = {
     "nav_links": [
         {"href": "talktorials", "internal": True, "title": "Our talktorials"},
         {"href": "installing", "internal": True, "title": "Run locally"},
-        {"href": "contribute", "internal": True, "title": "Contribute"},
+        {"href": "contribute", "internal": True, "title": "Development"},
+        {"href": "contact", "internal": True, "title": "Contact"},
+        {"href": "citation", "internal": True, "title": "Citation"},
         # {
         #     "href": "https://squidfunk.github.io/mkdocs-material/",
         #     "internal": False,

--- a/docs/contact.rst
+++ b/docs/contact.rst
@@ -1,0 +1,9 @@
+Contact
+=======
+
+Please contact us if you have questions or suggestions!
+
+- If you have questions regarding our Jupyter Notebooks, please `open an issue <https://github.com/volkamerlab/teachopencadd/issues>`_ on our GitHub repository.
+- If you have ideas for new topics, please fill out our `questionnaire <http://contribute.volkamerlab.org>`_.
+
+We are looking forward to hearing from you!

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -1,19 +1,3 @@
-Acknowledgments
-===============
-
-TeachOpenCADD has been initiated by the members of `Volkamer Lab <https://volkamerlab.org/>`_,
-Charité - Universitätsmedizin Berlin, with special thanks to
-`@dominiquesydow <https://github.com/dominiquesydow/>`_,
-`@jaimergp <https://github.com/jaimergp/>`_ and
-`@AndreaVolkamer <https://github.com/andreavolkamer>`_.
-The platform has been filled with life by our students from the CADD courses taught in the
-bioinformatics program at Freie Universität Berlin.
-
-Many thanks to everyone who has contributed and is contributing to TeachOpenCADD
-by working on talktorials (check out the talktorial READMEs for author information)
-and/or by helping in any other way
-(see `GitHub contributors <https://github.com/volkamerlab/teachopencadd/graphs/contributors>`_).
-
 For contributors
 ================
 

--- a/docs/external_dependencies.rst
+++ b/docs/external_dependencies.rst
@@ -1,6 +1,9 @@
 Packages and webservers used in TeachOpenCADD
 =============================================
 
+TeachOpenCADD uses several external packages and webservers as listed below. 
+If we are using your resource and forgot to add it here, please let us know, thank you!
+
 Python packages
 ---------------
 
@@ -76,5 +79,3 @@ Databases and webservers
 - KLIFS: https://klifs.net/
 - PubMed: https://pubchem.ncbi.nlm.nih.gov/
 - ProteinsPlus: https://proteins.plus/
-
-If we are using your resource and forgot to add it here, please contact us so that we can rectify this, thank you!

--- a/docs/external_dependencies.rst
+++ b/docs/external_dependencies.rst
@@ -1,4 +1,80 @@
 Packages and webservers used in TeachOpenCADD
----------------------------------------------
+=============================================
 
-Please find the full list on `GitHub <https://github.com/volkamerlab/teachopencadd#external-resources-1>`_.
+Python packages
+---------------
+
+- Cheminformatics and structural bioinformatics:
+
+  - ``rdkit``: http://rdkit.org/
+  - ``openbabel``: https://openbabel.org/
+  - ``mdanalysis``: https://www.mdanalysis.org/
+  - ``biopython``: https://biopython.org/
+  - ``biopandas``: http://rasbt.github.io/biopandas/
+  - ``opencadd``: https://opencadd.readthedocs.io/en/latest/
+  - ``plip``: https://github.com/pharmai/plip
+  - ``openff``: https://github.com/openforcefield/openff-toolkit
+  - ``openff-toolkit``: https://github.com/openforcefield/openff-toolkit
+  - ``openmmforcefields``: https://github.com/openmm/openmmforcefields
+  - ``pdbfixer``: https://github.com/openmm/pdbfixer
+  - ``mdanalysis``: https://www.mdanalysis.org/
+  - ``biotite``: https://www.biotite-python.org/
+  - ``smina``: https://sourceforge.net/p/smina/discussion/
+
+- Data science (PyData stack):
+
+  - ``numpy``: https://numpy.org/
+  - ``pandas``: https://pandas.pydata.org/
+  - ``scikit-learn``: https://scikit-learn.org/
+  - ``keras``: https://keras.io/
+  - ``jupyter``: https://jupyter.org/
+  - ``ipywidgets``: https://ipywidgets.readthedocs.io
+
+- Data visualization:
+
+  - ``matplotlib``: https://matplotlib.org/ 
+  - ``mpl_toolkits``: https://matplotlib.org/stable/api/toolkits/mplot3d.html
+  - ``matplotlib_venn``: https://github.com/konstantint/matplotlib-venn
+  - ``seaborn``: https://seaborn.pydata.org/
+  - ``nglview``: http://nglviewer.org/nglview/latest/
+
+- Web services clients:
+
+  - ``pypdb``: https://github.com/williamgilpin/pypdb
+  - ``chembl_webresource_client``: https://github.com/chembl/chembl_webresource_client
+  - ``requests``: https://requests.readthedocs.io/en/latest/
+  - ``bravado``: https://bravado.readthedocs.io/en/stable/
+  - ``beautifulsoup4``: https://www.crummy.com/software/BeautifulSoup/bs4/doc/
+
+- Utilities:
+
+  - ``tqdm``: https://tqdm.github.io/
+  - ``requests_cache``: https://requests-cache.readthedocs.io
+  - ``redo``: https://github.com/mozilla-releng/redo
+  - ``google-colab``: https://pypi.org/project/google-colab/
+  - ``condacolab``: https://pypi.org/project/condacolab/
+
+- Continuous integration:
+
+  - ``pytest``: https://docs.pytest.org
+  - ``nbval``: https://nbval.readthedocs.io
+
+- Documentation:
+
+  - ``sphinx``: https://www.sphinx-doc.org
+  - ``nbsphinx``: https://nbsphinx.readthedocs.io
+
+- Code style:
+
+  - ``black-nb``: https://github.com/tomcatling/black-nb
+
+Databases and webservers
+------------------------
+
+- ChEMBL: https://www.ebi.ac.uk/chembl/
+- RCSB PDB: https://www.rcsb.org/
+- KLIFS: https://klifs.net/
+- PubMed: https://pubchem.ncbi.nlm.nih.gov/
+- ProteinsPlus: https://proteins.plus/
+
+If we are using your resource and forgot to add it here, please contact us so that we can rectify this, thank you!

--- a/docs/external_tutorials_collections.rst
+++ b/docs/external_tutorials_collections.rst
@@ -7,7 +7,7 @@ Python programming
 The TeachOpenCADD platform is not a Python programming course from scratch but teaches how to solve tasks in cheminformatics and structural bioinformatics programmatically.
 If you wish to get started first with a Python programming introduction before diving into the TeachOpenCADD material, here are a few great resources to do so:
 
-- `AI in Medicine course <https://github.com/volkamerlab/ai_in_medicine>`_ by the `Volkamer Lab <https://volkamerlab.org/>`_ and `Ritter Lab <https://psychiatrie-psychotherapie.charite.de/metas/person/person/address_detail/ritter-7/>`_ at the Charité: Introduction to Python basics, Jupyter Notebook, and important data science packages such as Pandas, Matplotlib and Scikit-learn
+- `AI in Medicine course <https://github.com/volkamerlab/ai_in_medicine>`_ by the `Volkamer Lab <https://volkamerlab.org/>`_ and `Ritter Lab <https://psychiatrie-psychotherapie.charite.de/metas/person/person/address_detail/ritter-7/>`_ at the Charité: Introduction to Python basics, Jupyter Notebook, and important data science packages such as ``pandas``, ``matplotlib``, and ``scikit-learn``
 - `Python for Chemists course <https://github.com/GDChCICTeam/python-for-chemists>`_ by the `GDCh/CIC <https://en.gdch.de/network-structures/divisions/computers-in-chemistry-cic.html>`_ team: Crash-course introduction to Python for natural scientists
 - `MolSSI Education Resources <http://education.molssi.org/resources.html>`_ by `The Molecular Sciences Software Institute <https://molssi.org/>`_: Collection of tutorials on Python programming basics and data analysis but also more advanced material on software development and computational molecular science
 - `Core lessons <https://software-carpentry.org/lessons/>`_ by the `Software Carpentry <https://software-carpentry.org/>`_: Introduction to Python, Git, command line interfaces and more
@@ -29,3 +29,9 @@ The following resources are collections of interesting cheminformatics-related t
 - `Curated list of resources from the RDKit UGM 2020 <https://github.com/rdkit/UGM_2020/blob/master/info/curated_list_of_resources.md>`_
 - `A Highly Opinionated List of Open Source Cheminformatics Resources <https://github.com/PatWalters/resources/blob/main/cheminformatics_resources.md>`_ by Pat Walters
 - `Awesome Cheminformatics <https://github.com/hsiaoyi0504/awesome-cheminformatics#resources>`_ by Yi Hsiao
+
+
+Structural bioinformatics
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- `Education & Tutorials <https://www.bonvinlab.org/education/molmod_online/>`_ by the Bonvin Lab

--- a/docs/external_tutorials_collections.rst
+++ b/docs/external_tutorials_collections.rst
@@ -12,6 +12,7 @@ If you wish to get started first with a Python programming introduction before d
 - `MolSSI Education Resources <http://education.molssi.org/resources.html>`_ by `The Molecular Sciences Software Institute <https://molssi.org/>`_: Collection of tutorials on Python programming basics and data analysis but also more advanced material on software development and computational molecular science
 - `Core lessons <https://software-carpentry.org/lessons/>`_ by the `Software Carpentry <https://software-carpentry.org/>`_: Introduction to Python, Git, command line interfaces and more
 - `Best practices for Python, Git and Jupyter <https://zenodo.org/record/4630714>`_, a slide deck used in the introduction of our CADD Block course 2021, part of the Master's degree in Bioinformatics curriculum at the Freie Universität (FU) Berlin.
+- `5 Minutes of Fame <https://github.com/czodrowskilab/5minfame>`_ by the Czodrowski Lab are short sessions on Python-centric scientific and teachnological news
 
 .. _jupyter_tutorial:
 

--- a/docs/funding.rst
+++ b/docs/funding.rst
@@ -1,0 +1,5 @@
+Funding
+-------
+
+Volkamer Lab's projects are supported by several public funding sources
+(for more info see our `webpage <https://volkamerlab.org/>`_).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Table of contents
 
 .. toctree::
    :maxdepth: 1
-   :caption: Contributors
+   :caption: Development
 
    contribute
    api

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,26 +51,16 @@ Table of contents
 
 .. toctree::
    :maxdepth: 1
+   :caption: About TeachOpenCADD
+
+   acknowledgments
+   citation
+   license
+   funding
+
+.. toctree::
+   :maxdepth: 1
    :caption: External resources
 
    external_dependencies
    external_tutorials_collections
-
-
-Citation
---------
-
-If you make use of the TeachOpenCADD material in scientific publications,
-please cite our respective articles as summarized `here <https://github.com/volkamerlab/teachopencadd#citation>`_.
-
-Funding
--------
-
-Volkamer Lab's projects are supported by several public funding sources
-(for more info see our `webpage <https://volkamerlab.org/>`_).
-
-
-License
--------
-
-This work is licensed under the `Attribution 4.0 International (CC BY 4.0) <http://creativecommons.org/licenses/by/4.0/>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ Table of contents
    :maxdepth: 1
    :caption: About TeachOpenCADD
 
+   contact
    acknowledgments
    citation
    license

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -8,6 +8,9 @@ Installing
 
     If you installed ``mamba`` into an existing ``conda`` installation, also make sure that the ``conda-forge`` channel is configured by running ``conda config --add channels conda-forge``. 
 
+    If you prefer to work with ``conda``, please use ``conda`` in place of ``mamba`` in the instructions below. 
+    Please note that the TeachOpenCADD setup with ``conda`` takes much longer than with ``mamba``.
+
 
 Install from the conda package
 ------------------------------

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,4 @@
+License
+-------
+
+This work is licensed under the `Attribution 4.0 International (CC BY 4.0) <http://creativecommons.org/licenses/by/4.0/>`_.


### PR DESCRIPTION
## Description
Currently, we have documentation scattered between our TeachOpenCADD website (referred to here as "[docs](https://projects.volkamerlab.org/teachopencadd/)") and our repository [README](https://github.com/volkamerlab/teachopencadd/blob/master/README.md). Move most of the content from README to docs & add missing bits and pieces as outlined below.

## Todos
- [x] Docs: Add "About TeachOpenCADD" section that holds contact, acknowledgments, citation (updated!!), funding, and license (remove respective parts in README and instead link back to website)
- [x] Docs: Add note to installation that TeachOpenCADD can also be installed via `conda`, while `mamba` remains the preferred solution
- [x] Docs: Add external resources list to website and link back to it in README
- [x] Docs: Add "5 Minutes of Fame" by @czodrowskilab to external tutorial list
- [x] Docs: Update navigation menu (short-cuts to talktorial list, installation, contact, and citation)
- [x] README: Declutter everything that has been moved to docs; reduce number of headings

## Status
- [x] Ready to go