### PR TITLE
CI fails again with un-descriptive conda error message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       PACKAGE: teachopencadd
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,10 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.cfg.python-version }}
-          mamba-version: "*"
-          # Uncomment next line if you are running the tests locally via https://github.com/nektos/act
-          #miniconda-version: "latest"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           activate-environment: teachopencadd
-          channel-priority: true
           environment-file: devtools/test_env.yml
-          auto-activate-base: false
 
       - name: Additional info about the build
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,11 +23,10 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: "3.8"
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           activate-environment: teachopencadd
-          channel-priority: true
           environment-file: devtools/test_env.yml
-          auto-activate-base: false
 
       - name: Additional info about the build
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:


### PR DESCRIPTION
## Description
CI fails again with un-descriptive conda error message:
`Error: The process '/usr/share/miniconda/condabin/conda' failed with exit code 1`

See discussion here: https://github.com/conda-incubator/setup-miniconda/issues/116#issuecomment-1385554002
-> Might be resolved by using `mambaforge` instead of mamba as resolver.

## Todos
- [x] CI: Update actions/checkout from v2 to v3
- [x] CI: Use mambaforge instead of mamba as resolver

## Status
- [x] Ready to go