### PR TITLE
Docs CI: switch to linkinator

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd docs/_build/html
-          npx linkinator . --recurse --timeout 5000 \
+          npx linkinator . --verbosity error --recurse --timeout 5000 \
             -s "/*.txt" \
             -s "https://onlinelibrary.wiley.com/doi/full/10.1002/cmdc.200700139" \
             -s "https://onlinelibrary.wiley.com/doi/10.1002/9783527806539.*" \
@@ -69,10 +69,9 @@ jobs:
             -s "https://medium.com" \
             -s "https://*.medium.com" \
             -s "http[s]://quora.com" \
-            -s "http[s]://doi.org" \
+            -s "http[s]://doi.org/*" \
+            -s "http[s]://pubs.acs.org/*" \
             -s "ftp://*" \
-            -s "https://pubs.acs.org/doi/10.1021/acs.jcim.9b00662" \
-            -s "https://pubs.acs.org/doi/abs/10.1021/bk-2021-1387.ch010"
 
       - name: Check 404s (README)
         uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,20 +61,19 @@ jobs:
         shell: bash -l {0}
         run: |
           cd docs/_build/html
-          python -m http.server > /dev/null &2>1&
-          npx broken-link-checker http://localhost:8000/ --ordered --recursive \
-            --exclude "*.txt" \
-            --exclude "https://onlinelibrary.wiley.com/doi/full/10.1002/cmdc.200700139" \
-            --exclude "https://onlinelibrary.wiley.com/doi/10.1002/9783527806539.*" \
-            --exclude "https://towardsdatascience.com" \
-            --exclude "https://medium.com" \
-            --exclude "https://*.medium.com" \
-            --exclude "http[s]://quora.com" \
-            --exclude "http[s]://doi.org" \
-            --exclude "ftp://*" \
-            --exclude "http://localhost:8000" \
-            --exclude "https://pubs.acs.org/doi/10.1021/acs.jcim.9b00662" \
-            --exclude "https://pubs.acs.org/doi/abs/10.1021/bk-2021-1387.ch010"
+          npx linkinator . --recurse --timeout 5000 \
+            -s "/*.txt" \
+            -s "https://onlinelibrary.wiley.com/doi/full/10.1002/cmdc.200700139" \
+            -s "https://onlinelibrary.wiley.com/doi/10.1002/9783527806539.*" \
+            -s "https://towardsdatascience.com" \
+            -s "https://medium.com" \
+            -s "https://*.medium.com" \
+            -s "http[s]://quora.com" \
+            -s "http[s]://doi.org" \
+            -s "ftp://*" \
+            -s "http://localhost:8000" \
+            -s "https://pubs.acs.org/doi/10.1021/acs.jcim.9b00662" \
+            -s "https://pubs.acs.org/doi/abs/10.1021/bk-2021-1387.ch010"
 
       - name: Check 404s (README)
         uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,6 @@ jobs:
             -s "http[s]://quora.com" \
             -s "http[s]://doi.org" \
             -s "ftp://*" \
-            -s "http://localhost:8000" \
             -s "https://pubs.acs.org/doi/10.1021/acs.jcim.9b00662" \
             -s "https://pubs.acs.org/doi/abs/10.1021/bk-2021-1387.ch010"
 


### PR DESCRIPTION
## Description
Switch from `broken-link-checker` to `linkinator`. The former seems to be dead.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Check all dead links

## Questions
- [x] What's the reasoning behind the excludes?

## Status
- [x] Ready to go