### PR TITLE
[CI] Increase cell timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --nbval-cell-timeout 900 --current-env --dist loadscope --numprocesses 2"
+          PYTEST_ARGS="--nbval-lax --nbval-cell-timeout 1800 --current-env --dist loadscope --numprocesses 2"
 
           PYTEST_IGNORE_T019="--ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb"
           PYTEST_IGNORE_T020="--ignore=teachopencadd/talktorials/T020_md_analysis/talktorial.ipynb"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
+          PYTEST_ARGS="--nbval-lax --nbval-cell-timeout 600 --current-env --dist loadscope --numprocesses 2"
 
           PYTEST_IGNORE_T019="--ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb"
           PYTEST_IGNORE_T020="--ignore=teachopencadd/talktorials/T020_md_analysis/talktorial.ipynb"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --nbval-cell-timeout 600 --current-env --dist loadscope --numprocesses 2"
+          PYTEST_ARGS="--nbval-lax --nbval-cell-timeout 900 --current-env --dist loadscope --numprocesses 2"
 
           PYTEST_IGNORE_T019="--ignore=teachopencadd/talktorials/T019_md_simulation/talktorial.ipynb"
           PYTEST_IGNORE_T020="--ignore=teachopencadd/talktorials/T020_md_analysis/talktorial.ipynb"


### PR DESCRIPTION
## Description
Increase cell timeout in the pytest CI part to 10 minutes. This is double the current default. But maybe necessary to run the deep learning notebooks. See #370 

## Todos
- [ ] check if 10 minutes are enough for all notebooks

## Status
- [ ] Ready to go