### PR TITLE
Dev pytorch from forge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
             python-version: "3.9"
           - os: macos-latest
             python-version: "3.8"
-          - os: windows-latest
-            python-version: "3.8"
 
     env:
       PYVER: ${{ matrix.cfg.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: ${{ matrix.cfg.python-version }}
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          activate-environment: teachopencadd
+          activate-environment: teachopencadd_test
           environment-file: devtools/test_env.yml
 
       - name: Additional info about the build

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -1,4 +1,4 @@
-name: teachopencadd
+name: teachopencadd_test
 channels:
   - conda-forge
   - defaults

--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - mkl < 2022
-  - pytorch::pytorch==1.13.0
+  - pytorch==1.13.0
   #- pyg::pyg==2.2.0
   - python>=3.8
   - pip


### PR DESCRIPTION
## Description
The current dev branch cannot be published on conda-forge due to PyTorch not being installed from conda-forge but from the pytorch channel. Therefore, I changed the PyTorch installation channel from PyTorch to conda-forge in the CI/CD pipeline to test if the test succeeds with the new dependencies.

## Todos
- [ ] If the tests succeed, one has to adjust the conda-forge upload to use PyTorch from conda-forge.

## Questions
No questions so far.

## Status
- [ ] Ready to go