### PR TITLE
Environment package ordering

### DIFF
--- a/devtools/test_env.yml
+++ b/devtools/test_env.yml
@@ -3,9 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - mkl < 2022
-  - pytorch::pytorch==1.13.0
-  #- pyg::pyg==2.2.0
   - python>=3.8
   - pip
   - jupyterlab>=3
@@ -42,6 +39,9 @@ dependencies:
   - mdtraj
   - plip
   - openmm
+  - mkl < 2022
+  - pytorch::pytorch==1.13.0
+  #- pyg::pyg==2.2.0  # installed manually for now
   # Dependency not included, see https://github.com/volkamerlab/teachopencadd/issues/313
   # - openmmforcefields
   - pdbfixer


### PR DESCRIPTION
## Description
See #389. This PR moves the DL packages to the back of the depency list in `devtools/test_env.yml`.

## Status
- [x] Ready to go