### PR TITLE
Install docs: add a note about missing dl packages

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -14,6 +14,9 @@ Installing
 
 Install from the conda package
 ------------------------------
+.. note::
+
+    The conda package does not yet include all packages necessary to run the deep learning edition talktorials (T033-T038).
 
 1. Create a new conda environment for TeachOpenCADD::
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -18,6 +18,8 @@ Install from the conda package
 
     The conda package does not yet include all packages necessary to run the deep learning edition talktorials (T033-T038).
 
+    We are working on it and will post an update as soon as the new package is available.
+
 1. Create a new conda environment for TeachOpenCADD::
 
     # Linux / MacOS


### PR DESCRIPTION
## Description
This adds a short note to the conda install instructions on the missing DL edition packages.

## Questions
- [x] Is this note sufficient?

## Status
- [x] Ready to go