### PR TITLE
Separate environment for T018

### DIFF
--- a/teachopencadd/talktorials/T018_automated_cadd_pipeline/environment.yml
+++ b/teachopencadd/talktorials/T018_automated_cadd_pipeline/environment.yml
@@ -1,0 +1,21 @@
+name: teachopencadd-t018
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python = 3.12.1
+  - jupyterlab = 4.1.1
+  - numpy = 1.26.4
+  - pandas = 2.1.4  # not 2.2.x due to this problem in RDKit: https://github.com/rdkit/rdkit/pull/7165
+  - matplotlib = 3.8.2
+  - rdkit = 2023.09.5
+  - nglview = 3.1.1
+  - openbabel = 3.1.1
+  - biopandas = 0.4.1
+  - pypdb = 2.3
+  - mdanalysis = 2.7.0
+  - plip = 2.3.0
+  - smina = 2020.12.10
+  - requests = 2.31.0
+  - redo = 2.0.4
+  - ipywidgets = 8.1.2

--- a/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/__init__.py
+++ b/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/__init__.py
@@ -2,6 +2,10 @@
 Main classes used in Talktorial T018.
 """
 
+import warnings
+warnings.simplefilter("ignore", category=DeprecationWarning)
+warnings.simplefilter("ignore", category=FutureWarning)
+
 from .consts import Consts
 from .specs import Specs
 from .protein import Protein

--- a/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/helpers/pdb.py
+++ b/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/helpers/pdb.py
@@ -7,7 +7,7 @@ import warnings
 
 from biopandas.pdb import PandasPdb  # for working with PDB files
 import pypdb  # for communicating with the RCSB Protein Data Bank (PDB) to fetch PDB files
-from opencadd.structure.core import Structure  # for manipulating PDB files
+import MDAnalysis  # for manipulating PDB files
 
 
 def read_pdb_file_content(input_type, input_value):
@@ -81,13 +81,13 @@ def extract_molecule_from_pdb_file(molecule_name, input_filepath, output_filepat
         Structure object of the extracted molecule.
     """
 
-    pdb_structure = Structure.from_string(input_filepath)
+    pdb_structure = MDAnalysis.Universe(input_filepath)
     molecule_name = f"resname {molecule_name}" if molecule_name != "protein" else molecule_name
     extracted_structure = pdb_structure.select_atoms(molecule_name)
     if output_filepath is not None:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            extracted_structure.write(Path(output_filepath).with_suffix(".pdb"))
+            extracted_structure.atoms.write(Path(output_filepath).with_suffix(".pdb"))
     return extracted_structure
 
 

--- a/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/helpers/plip.py
+++ b/teachopencadd/talktorials/T018_automated_cadd_pipeline/utils/helpers/plip.py
@@ -5,6 +5,7 @@ Set of functions required to analyze protein-ligand interactions using the PLIP 
 from enum import Enum  # for creating enumeration classes
 from pathlib import Path  # for creating folders and handling local paths
 import logging  # for setting logging levels (to disable logging defaults of packages e.g. PLIP)
+import warnings
 
 import plip  # for changing the logging setting of the package (see bottom of the cell: Settings)
 # for calculating protein-ligand interactions
@@ -15,8 +16,8 @@ import pandas as pd  # for creating dataframes and handling data
 
 # Settings:
 # disabling excessive INFO logs of the PLIP package
-logging.getLogger(plip.__name__).setLevel(logging.WARNING)
-
+logging.getLogger(plip.__name__).setLevel(logging.ERROR)
+warnings.simplefilter("ignore", category=DeprecationWarning)
 
 class Consts:
     """


### PR DESCRIPTION
A separate environment is added to T018:
- all dependencies are pinned exactly (i.e., `major.minor.patch`) to their latest working versions.
- For all dependencies except `pandas`, this version is the latest version resolved by `conda`.
- `pandas` is pinned to `2.1.4` (i.e., the latest `2.1.x` version) instead of `2.2.0` (i.e., the latest resolvable version) because the latest `RDKit` version (i.e., `2023.09.5`) does not work with `pandas 2.2.0`. I fixed the issue in `RDKit` and submitted a [PR](https://github.com/rdkit/rdkit/pull/7165). Once a new `RDKit` release with this fix is released, we can update the `pandas` dependency to the latest version.

In addition, the following changes are applied to the `utils` subpackage in T018 (i.e., the backend of T018):
- `DeprecationWarning` and `FutureWarning` notifications are suppressed to not show up in notebook outputs. These are all due to our dependencies not having updated their codes to adopt to newer versions of their own dependencies.
- The `opencadd` dependency is removed, and replaced with `MDAnalysis`: The utility we used in OpenCADD (i.e. `opencadd.structure.core.Structure`) is just a wrapper around `MDAnalysis.Universe` with no added functionalities. Therefore, the `opencadd` dependency was removed and `MDAnalysis` was used directly instead, in order to avoid version pinning problems in `opencadd`.

Lastly the notebook is rerun:
- This caused some slight (numerical) changes (e.g. calculated binding affinities by `smina`, calculated interactions by `plip`) in the outputs, which were mentioned in the text. Therefore, the text was also edited to reflect the new results.